### PR TITLE
feat(admin): show additional details when exporting shipments from individual order pages

### DIFF
--- a/apps/admin/src/components/OrderBox/ShipmentOptionsBox.vue
+++ b/apps/admin/src/components/OrderBox/ShipmentOptionsBox.vue
@@ -20,6 +20,13 @@
             :order="data?.externalIdentifier" />
         </PdkCol>
       </PdkRow>
+
+      <PdkRow>
+        <PdkCol>
+          <NotificationContainer
+            :category="NotificationCategory.Action" />
+        </PdkCol>
+      </PdkRow>
     </template>
   </PdkConceptBoxWrapper>
 </template>
@@ -28,7 +35,7 @@
 import {computed, toValue} from 'vue';
 import {ShipmentOptionsForm} from '../common';
 import {instantiateActions} from '../../services';
-import {AdminIcon} from '../../data';
+import {AdminIcon, NotificationCategory} from '../../data';
 import {useLanguage, useOrderData, usePluginSettings} from '../../composables';
 import {
   orderExportAction,
@@ -38,6 +45,7 @@ import {
   ordersUpdateAction,
   orderViewInBackofficeAction,
 } from '../../actions';
+import {NotificationContainer} from '../../components';
 
 const {order: data, loading} = useOrderData();
 

--- a/apps/admin/src/forms/helpers/getDeliveryTypes.ts
+++ b/apps/admin/src/forms/helpers/getDeliveryTypes.ts
@@ -1,0 +1,19 @@
+import {type FormInstance} from '@myparcel/vue-form-builder';
+import {DeliveryTypeName, PackageTypeName} from '@myparcel/constants';
+import {getDynamicTranslation} from '../../utils';
+import {type SelectOption} from '../../types';
+import {getCarrier} from './getCarrier';
+
+export const getDeliveryTypes = (form?: FormInstance): SelectOption[] => {
+  let array = Object.values(DeliveryTypeName);
+
+  if (form) {
+    const carrier = getCarrier(form);
+    array = array.filter((name) => carrier?.capabilities.deliveryTypes.includes(name));
+  }
+
+  return array.map((name) => ({
+    label: getDynamicTranslation('delivery_type', name),
+    value: name,
+  }));
+};

--- a/apps/admin/src/forms/helpers/getDeliveryTypes.ts
+++ b/apps/admin/src/forms/helpers/getDeliveryTypes.ts
@@ -1,5 +1,5 @@
 import {type FormInstance} from '@myparcel/vue-form-builder';
-import {DeliveryTypeName, PackageTypeName} from '@myparcel/constants';
+import {DeliveryTypeName} from '@myparcel/constants';
 import {getDynamicTranslation} from '../../utils';
 import {type SelectOption} from '../../types';
 import {getCarrier} from './getCarrier';

--- a/apps/admin/src/forms/helpers/getPackageTypes.ts
+++ b/apps/admin/src/forms/helpers/getPackageTypes.ts
@@ -9,7 +9,6 @@ export const getPackageTypes = (form?: FormInstance): SelectOption[] => {
 
   if (form) {
     const carrier = getCarrier(form);
-
     array = array.filter((name) => carrier?.capabilities.packageTypes.includes(name));
   }
 

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
@@ -13,6 +13,7 @@ import {AdminModalKey} from '../../data';
 import {useAdminConfig} from '../../composables';
 import {type ShipmentOptionsRefs} from './types';
 import {createHideSenderField} from './fields/createHideSenderField';
+import {createDeliveryTypeField} from './fields/createDeliveryTypeField';
 import {
   createAgeCheckField,
   createCarrierField,
@@ -56,14 +57,19 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
     ...(isModal ? config.formConfigOverrides?.modal : null),
     ...config.formConfigOverrides?.shipmentOptions,
     fields: [
+      // General delivery options
       createCarrierField(refs, order.inheritedDeliveryOptions),
 
       createPackageTypeField(refs),
+
+      createDeliveryTypeField(refs),
+      // TODO: add pickup location obj. (read only? conditional on delivery type)
 
       createLabelAmountField(refs),
 
       createDigitalStampRangeField(refs),
 
+      // Actual shipment options
       createAgeCheckField(refs),
       createSignatureField(refs),
       createOnlyRecipientField(refs),
@@ -72,7 +78,7 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
       createHideSenderField(refs),
       createSameDayDeliveryField(refs),
       createReceiptCodeField(refs),
-      createInsuranceField(refs),
+      createInsuranceField(refs), // FIXME: not saved or rendered correctly
     ],
   });
 };

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
@@ -63,7 +63,6 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
       createPackageTypeField(refs),
 
       createDeliveryTypeField(refs),
-      // TODO: add pickup location obj. (read only? conditional on delivery type)
 
       createLabelAmountField(refs),
 
@@ -78,7 +77,7 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
       createHideSenderField(refs),
       createSameDayDeliveryField(refs),
       createReceiptCodeField(refs),
-      createInsuranceField(refs), // FIXME: not saved or rendered correctly
+      createInsuranceField(refs),
     ],
   });
 };

--- a/apps/admin/src/forms/shipmentOptions/field.ts
+++ b/apps/admin/src/forms/shipmentOptions/field.ts
@@ -16,9 +16,12 @@ export const LABEL_AMOUNT = 'labelAmount' satisfies keyof Shipment.ModelDelivery
 
 export const PACKAGE_TYPE = 'packageType' satisfies keyof Shipment.ModelDeliveryOptions;
 
+export const DELIVERY_TYPE = 'deliveryType' satisfies keyof Shipment.ModelDeliveryOptions;
+
 export const AGE_CHECK = 'ageCheck' satisfies keyof Shipment.ModelShipmentOptions;
 
 export const RECEIPT_CODE = 'receiptCode' satisfies keyof Shipment.ModelShipmentOptions;
+
 export const DIRECT_RETURN = 'return' satisfies keyof Shipment.ModelShipmentOptions;
 
 export const HIDE_SENDER = 'hideSender' satisfies keyof Shipment.ModelShipmentOptions;
@@ -46,6 +49,8 @@ export const FIELD_CARRIER: FieldName = `${DELIVERY_OPTIONS_PREFIX}.${CARRIER}`;
 export const FIELD_LABEL_AMOUNT: FieldName = `${DELIVERY_OPTIONS_PREFIX}.${LABEL_AMOUNT}`;
 
 export const FIELD_PACKAGE_TYPE: FieldName = `${DELIVERY_OPTIONS_PREFIX}.${PACKAGE_TYPE}`;
+
+export const FIELD_DELIVERY_TYPE: FieldName = `${DELIVERY_OPTIONS_PREFIX}.${DELIVERY_TYPE}`;
 
 export const FIELD_AGE_CHECK: FieldName = `${SHIPMENT_OPTIONS_PREFIX}.${AGE_CHECK}`;
 
@@ -78,6 +83,7 @@ export const ALL_FIELDS = [
   FIELD_ONLY_RECIPIENT,
   FIELD_MANUAL_WEIGHT,
   FIELD_PACKAGE_TYPE,
+  FIELD_DELIVERY_TYPE,
   FIELD_SAME_DAY_DELIVERY,
   FIELD_SIGNATURE,
   FIELD_RECEIPT_CODE,

--- a/apps/admin/src/forms/shipmentOptions/fields/createCarrierField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createCarrierField.ts
@@ -3,7 +3,8 @@ import {AdminContextKey, type Plugin} from '@myparcel-pdk/common';
 import {type InteractiveElementConfiguration} from '@myparcel/vue-form-builder';
 import {PackageTypeName} from '@myparcel/constants';
 import {type ShipmentOptionsRefs} from '../types';
-import {FIELD_CARRIER, FIELD_INSURANCE, FIELD_PACKAGE_TYPE, PROP_OPTIONS} from '../field';
+import {FIELD_CARRIER, FIELD_DELIVERY_TYPE, FIELD_INSURANCE, FIELD_PACKAGE_TYPE, PROP_OPTIONS} from '../field';
+import {getDeliveryTypes} from '../../helpers/getDeliveryTypes';
 import {
   defineFormField,
   getInsuranceOptions,
@@ -74,6 +75,7 @@ export const createCarrierField = (
 
       setFieldProp(field.form, FIELD_INSURANCE, PROP_OPTIONS, getInsuranceOptions(field, formatter));
       setFieldProp(field.form, FIELD_PACKAGE_TYPE, PROP_OPTIONS, getPackageTypes(field.form));
+      setFieldProp(field.form, FIELD_DELIVERY_TYPE, PROP_OPTIONS, getDeliveryTypes(field.form));
 
       setPostNlAgeCheckSubtext(field);
     },

--- a/apps/admin/src/forms/shipmentOptions/fields/createDeliveryTypeField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createDeliveryTypeField.ts
@@ -1,17 +1,17 @@
 import {snakeCase} from 'lodash-unified';
 import {type InteractiveElementConfiguration} from '@myparcel/vue-form-builder';
-import {PackageTypeName} from '@myparcel/constants';
+import {DeliveryTypeName} from '@myparcel/constants';
 import {type ShipmentOptionsRefs} from '../types';
-import {FIELD_PACKAGE_TYPE, SHIPMENT_OPTIONS} from '../field';
+import {FIELD_DELIVERY_TYPE, SHIPMENT_OPTIONS} from '../field';
 import {defineFormField, resolveFormComponent} from '../../helpers';
 import {AdminComponent} from '../../../data';
 import {createRef} from './createRef';
 
-export const createPackageTypeField = (refs: ShipmentOptionsRefs): InteractiveElementConfiguration => {
+export const createDeliveryTypeField = (refs: ShipmentOptionsRefs): InteractiveElementConfiguration => {
   return defineFormField({
-    name: FIELD_PACKAGE_TYPE,
-    label: snakeCase(`${SHIPMENT_OPTIONS}_package_type`),
-    ref: createRef<PackageTypeName>(refs, FIELD_PACKAGE_TYPE, PackageTypeName.Package),
+    name: FIELD_DELIVERY_TYPE,
+    label: snakeCase(`${SHIPMENT_OPTIONS}_delivery_type`),
+    ref: createRef<DeliveryTypeName>(refs, FIELD_DELIVERY_TYPE, DeliveryTypeName.Standard),
     component: resolveFormComponent(AdminComponent.RadioGroup),
     // options defined in afterUpdate of `createCarrierField`
   });


### PR DESCRIPTION
show and allow changes to the shipment type, and display any (error) notifications when executing actions from any page showing the SipmentOptionsBox (individual order pages in the admin)

fixes INT-792