### PR TITLE
fix(checkout): fix pdk checkout form type to allow additional fields

### DIFF
--- a/libs/checkout-common/src/types/checkout.types.ts
+++ b/libs/checkout-common/src/types/checkout.types.ts
@@ -19,9 +19,12 @@ export type PdkCheckoutConfigInput = Omit<
   };
 };
 
+/**
+ * Includes our own address fields, and any additional fields described by optional packages.
+ */
 export type PdkCheckoutForm = Record<PdkField, string> & {
-  [AddressType.Billing]: AddressFields;
-  [AddressType.Shipping]: AddressFields;
+  [AddressType.Billing]: AddressFields & Record<string, string>;
+  [AddressType.Shipping]: AddressFields & Record<string, string>;
 };
 
 export interface PdkCheckoutConfig {

--- a/libs/checkout-common/src/utils/global/getAddressField.ts
+++ b/libs/checkout-common/src/utils/global/getAddressField.ts
@@ -16,6 +16,5 @@ export const getAddressField = (
   const config = useConfig();
   const getElement = useUtil(PdkUtil.GetElement);
 
-  // @ts-expect-error todo
   return getElement(config.fields[resolvedAddressType][name], warn);
 };


### PR DESCRIPTION
fixes the pdk checkout form type to allow additional field name mappings, like those for the separate address fields

fixes INT-716