### PR TITLE
feat(admin): support showing error notifications passed by PDK

### DIFF
--- a/apps/admin/src/sdk/PdkFetchClient.ts
+++ b/apps/admin/src/sdk/PdkFetchClient.ts
@@ -31,6 +31,14 @@ export class PdkFetchClient extends FetchClient {
     const response = (await this.request(endpoint, newOptions)) as ResponseWrapper<PdkEndpointResponseBody<E>>;
 
     if (isOfType<ErrorResponse>(response, 'errors')) {
+      if (isOfType<EndpointResponseBodyWithNotifications>(response, 'notifications')) {
+        const notificationStore = useNotificationStore();
+
+        response.notifications.forEach((notification) => {
+          notificationStore.add(notification);
+        });
+      }
+
       throw new ApiException(response);
     }
 

--- a/apps/admin/src/services/addErrorToNotifications.ts
+++ b/apps/admin/src/services/addErrorToNotifications.ts
@@ -14,13 +14,15 @@ export const addErrorToNotifications = (
   const store = useNotificationStore();
   const options: Partial<PdkNotification> = {category, timeout};
 
-  if (isOfType<ApiException>(error, 'data')) {
-    options.content = error.data.errors.map((error) => `${error.title} (code: ${error.code})`);
-  }
-
   if (isOfType<Error>(error, 'message')) {
     options.title = error.message;
+
     options.content = error.stack;
+  }
+
+  // Override stacktrace if the error is an ApiException
+  if (isOfType<ApiException>(error, 'data')) {
+    options.content = error.data.errors.map((error) => `${error.title} (code: ${error.code})`);
   }
 
   const notification = createNotification(Variant.Error, options);


### PR DESCRIPTION
supports showing notifications passed by the PHP PDK in the UI. effectively will render validation errors from the API in the UI visible to the end user.
    
fixes INT-928