### PR TITLE
build: dump autoload after renaming/scoping files

### DIFF
--- a/apps/app-builder/src/constants.ts
+++ b/apps/app-builder/src/constants.ts
@@ -34,6 +34,8 @@ export const COMMAND_UPGRADE_SELF_NAME = 'upgrade-self';
 
 export const COMMAND_ZIP_NAME = 'zip';
 
+export const COMMAND_AUTOLOAD_NAME = 'dump-autoload';
+
 export type CommandName =
   | typeof COMMAND_CLEAN_NAME
   | typeof COMMAND_COPY_NAME
@@ -44,7 +46,8 @@ export type CommandName =
   | typeof COMMAND_TRANSFORM_NAME
   | typeof COMMAND_TRANSLATIONS_NAME
   | typeof COMMAND_UPGRADE_NAME
-  | typeof COMMAND_ZIP_NAME;
+  | typeof COMMAND_ZIP_NAME
+  | typeof COMMAND_AUTOLOAD_NAME;
 
 export enum VerbosityLevel {
   Verbose = 1,

--- a/apps/app-builder/src/definitions.ts
+++ b/apps/app-builder/src/definitions.ts
@@ -3,6 +3,7 @@ import {defineBulkCommand} from './utils/defineBulkCommand';
 import {type AnyCommandDefinition} from './types/command.types';
 import {type BulkCommandDefinition} from './types/bulkCommand.types';
 import {
+  COMMAND_AUTOLOAD_NAME,
   COMMAND_BUILD_NAME,
   COMMAND_CLEAN_NAME,
   COMMAND_COPY_NAME,
@@ -101,6 +102,12 @@ export const upgradeCommand = defineCommand<UpgradeCommandArgs>({
   args: [['[package]', 'Package to upgrade']],
 });
 
+export const dumpAutoloadCommand = defineCommand({
+  name: COMMAND_AUTOLOAD_NAME,
+  action: () => import('./commands/dumpAutoload'),
+  description: 'Run composer autoload command.',
+});
+
 export const zipCommand = defineCommand({
   name: COMMAND_ZIP_NAME,
   action: () => import('./commands/zip'),
@@ -160,12 +167,12 @@ export const upgradeSelfCommand = defineBulkCommand({
 export const preReleaseBulkCommand = defineBulkCommand({
   name: COMMAND_PRERELEASE_NAME,
   description: 'Prepare a release.',
-  commands: [cleanCommand, scopePhpCommand, incrementCommand, ...CORE_COMMANDS, zipCommand],
+  commands: [cleanCommand, scopePhpCommand, incrementCommand, ...CORE_COMMANDS, dumpAutoloadCommand, zipCommand],
 });
 
 export const releaseBulkCommand = defineBulkCommand({
   name: COMMAND_RELEASE_NAME,
-  commands: [cleanCommand, scopePhpCommand, incrementCommand, ...CORE_COMMANDS, zipCommand],
+  commands: [cleanCommand, scopePhpCommand, incrementCommand, ...CORE_COMMANDS, dumpAutoloadCommand, zipCommand],
 });
 
 export const ALL_COMMANDS: readonly AnyCommandDefinition[] = Object.freeze([


### PR DESCRIPTION
fixes a problem where autoload/autoload_static.php might contain incorrect namespaces

fixes INT-1043