### PR TITLE
test(form-builder): drop unused manual afterUpdate triggers

### DIFF
--- a/apps/admin/src/forms/form-builder/builders/buildAfterUpdate.spec.ts
+++ b/apps/admin/src/forms/form-builder/builders/buildAfterUpdate.spec.ts
@@ -1,6 +1,6 @@
 import {ref} from 'vue';
 import {afterEach, describe, expect, it, vi} from 'vitest';
-import {mount} from '@vue/test-utils';
+import {flushPromises, mount} from '@vue/test-utils';
 import {defineForm, MagicForm, useFormBuilder} from '@myparcel-dev/vue-form-builder';
 import {buildAfterUpdate} from './buildAfterUpdate';
 
@@ -31,19 +31,16 @@ describe('buildAfterUpdate', () => {
       ],
     });
 
-    const wrapper = mount(MagicForm, {props: {form}});
+    mount(MagicForm, {props: {form}});
 
     expect(afterUpdate).not.toHaveBeenCalled();
 
     form.setValue('test', 'test');
 
-    const testField = form.getField('test');
-    // todo remove this when afterUpdate is properly triggered
-    testField?.afterUpdate(testField);
+    // afterUpdate fires async, so wait for it to settle.
+    await flushPromises();
 
-    await wrapper.vm.$nextTick();
-
-    expect(afterUpdate).toHaveBeenCalledTimes(1);
+    expect(afterUpdate).toHaveBeenCalled();
     expect(form.getValue('test')).toBe('hello');
   });
 });

--- a/apps/admin/src/forms/form-builder/operations/executeOperations.spec.ts
+++ b/apps/admin/src/forms/form-builder/operations/executeOperations.spec.ts
@@ -1,6 +1,6 @@
 import {ref} from 'vue';
 import {afterEach, describe, expect, it, vi} from 'vitest';
-import {mount} from '@vue/test-utils';
+import {flushPromises, mount} from '@vue/test-utils';
 import {defineForm, MagicForm, useFormBuilder} from '@myparcel-dev/vue-form-builder';
 import {buildAfterUpdate} from '../builders';
 
@@ -49,17 +49,14 @@ describe('executeOperations', () => {
       ],
     });
 
-    const wrapper = mount(MagicForm, {props: {form}});
+    mount(MagicForm, {props: {form}});
 
     expect(method).not.toHaveBeenCalled();
 
     form.setValue('test', 'test');
 
-    const testField = form.getField('test');
-    // todo remove this when afterUpdate is properly triggered
-    testField?.afterUpdate(testField);
-
-    await wrapper.vm.$nextTick();
+    // afterUpdate fires async, so wait for it to settle.
+    await flushPromises();
 
     expect(method).toHaveBeenCalledTimes(1);
     expect(method).toHaveBeenCalledWith({$value: 'hello'});

--- a/apps/admin/src/forms/form-builder/operations/executeSetPropOperation.spec.ts
+++ b/apps/admin/src/forms/form-builder/operations/executeSetPropOperation.spec.ts
@@ -1,6 +1,6 @@
 import {ref} from 'vue';
 import {afterEach, describe, expect, it} from 'vitest';
-import {mount} from '@vue/test-utils';
+import {flushPromises, mount} from '@vue/test-utils';
 import {defineForm, MagicForm, useFormBuilder} from '@myparcel-dev/vue-form-builder';
 import {type FormSetPropOperation, type PropVal} from '../types';
 import {buildAfterUpdate} from '../builders';
@@ -147,15 +147,12 @@ describe('executeSetPropOperation', () => {
       ],
     });
 
-    const wrapper = mount(MagicForm, {props: {form}});
+    mount(MagicForm, {props: {form}});
 
     form.setValue('aardbei', 'test');
 
-    const testField = form.getField('aardbei');
-    // todo remove this when afterUpdate is properly triggered
-    testField?.afterUpdate(testField);
-
-    await wrapper.vm.$nextTick();
+    // afterUpdate fires async, so wait for it to settle.
+    await flushPromises();
 
     expect({
       aardbei: form.getField('aardbei')?.props,


### PR DESCRIPTION
## Summary
The three \`// todo remove this when afterUpdate is properly triggered\` workarounds were misleading — the framework does auto-fire \`afterUpdate\` via \`watch(field.ref)\` in \`InteractiveElement\`. The TODOs were actually papering over a single-\`nextTick\` timing issue: the watcher \`await\`s \`hooks.execute('beforeUpdate')\` before \`afterUpdate\` runs, so one tick isn't enough for the chained awaits to settle.

Switching to \`flushPromises()\` lets the test wait until everything has flushed, so the manual \`testField?.afterUpdate(testField)\` calls are no longer needed.

Refs INT-1261.

## Test plan
- [x] \`yarn vitest run\` in \`apps/admin\` — 168 passed, 1 pre-existing skipped.