### PR TITLE
feat(admin): adopt @myparcel-dev/sdk 5.1 for capabilities endpoint

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@myparcel-dev/constants": "^2.9.0",
     "@myparcel-dev/pdk-common": "workspace:^1.12.0",
-    "@myparcel-dev/sdk": "^5.0.0",
+    "@myparcel-dev/sdk": "^5.1.0",
     "@myparcel-dev/vue-form-builder": "1.0.0-beta.42.6",
     "@tanstack/vue-query": "~4.43.0",
     "@vueuse/core": "^10.0.0",

--- a/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
@@ -2,8 +2,8 @@ import {computed, type Ref} from 'vue';
 import {useQuery} from '@tanstack/vue-query';
 import {BackendEndpoint} from '@myparcel-dev/pdk-common';
 import {type ProxyCapabilitiesBody, type ProxyCapabilitiesCall} from '../../../../types';
-import {globalLogger} from '../../../../services';
 import {type ResolvedQuery} from '../../../../stores';
+import {globalLogger} from '../../../../services';
 import {usePdkAdminApi} from '../../../../sdk';
 
 /**
@@ -24,10 +24,6 @@ export type OrderCapabilitiesInput = {
  *
  * Drives the carrier / packageType / deliveryType dropdowns. Refetches only on cc / weight
  * changes so option toggles and dropdown picks don't trigger needless network round-trips.
- *
- * Server-side option allowlist filtering is NOT applied here (no `filterOptions` parameter).
- * The shipment-scoped query is the source for option metadata (`requires` / `excludes`); the
- * order query response is consumed for type lists only.
  *
  * Errors are logged via `globalLogger.error` so we have a breadcrumb for support, but we
  * deliberately don't surface a user-facing toast — an intermittent capabilities failure
@@ -54,7 +50,7 @@ export const useOrderCapabilitiesQuery = (
         ...(weight !== undefined ? {physicalProperties: {weight: {value: weight, unit: 'g'}}} : null),
       };
 
-      const response = await proxyCapabilities({body});
+      const response = await proxyCapabilities({body, parameters: {filterSupported: true}});
 
       return response.results ?? [];
     },

--- a/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
@@ -2,8 +2,8 @@ import {computed, type Ref} from 'vue';
 import {useQuery} from '@tanstack/vue-query';
 import {BackendEndpoint} from '@myparcel-dev/pdk-common';
 import {type ProxyCapabilitiesBody, type ProxyCapabilitiesCall} from '../../../../types';
-import {globalLogger} from '../../../../services';
 import {type ResolvedQuery} from '../../../../stores';
+import {globalLogger} from '../../../../services';
 import {usePdkAdminApi} from '../../../../sdk';
 
 /**
@@ -15,9 +15,9 @@ import {usePdkAdminApi} from '../../../../sdk';
  * `packageType` AND `deliveryType` to be set before firing — anything less wouldn't yield
  * shipment-specific metadata.
  *
- * `options` and `filterOptions` are intentionally not part of the selection: option toggles
+ * `options` and `filterSupported` are intentionally not part of the selection: option toggles
  * don't drive refetches (option interactions resolve client-side), and the composable always
- * opts in to server-side allowlist filtering via the `filterOptions` query parameter.
+ * opts in to server-side allowlist filtering via the `filterSupported` query parameter.
  */
 export type CapabilitiesSelection = {
   cc?: string;
@@ -35,7 +35,7 @@ export type CapabilitiesSelection = {
  * valid for the order context.
  *
  * The selection ref is the only refetch trigger — no window-focus, mount, or reconnect refetches.
- * Server-side option filtering is opted in via the `filterOptions` query parameter so admin sees
+ * Server-side option filtering is opted in via the `filterSupported` query parameter so admin sees
  * the same option allowlist that `Carrier::attributesToArray` applies on the contract-definition
  * path.
  *
@@ -51,7 +51,9 @@ export const useShipmentCapabilitiesQuery = (
   selection: Readonly<Ref<CapabilitiesSelection>>,
 ): ResolvedQuery<BackendEndpoint.ProxyCapabilities> => {
   const enabled = computed(() =>
-    Boolean(selection.value.cc && selection.value.carrier && selection.value.packageType && selection.value.deliveryType),
+    Boolean(
+      selection.value.cc && selection.value.carrier && selection.value.packageType && selection.value.deliveryType,
+    ),
   );
   const queryKey = computed(() => [BackendEndpoint.ProxyCapabilities, 'shipment', selection.value] as const);
 
@@ -77,7 +79,7 @@ export const useShipmentCapabilitiesQuery = (
         deliveryType,
       };
 
-      const response = await proxyCapabilities({body, parameters: {filterOptions: 'true'}});
+      const response = await proxyCapabilities({body, parameters: {filterSupported: true}});
 
       return response.results ?? [];
     },

--- a/apps/admin/src/sdk/composables/usePdkAdminApi.ts
+++ b/apps/admin/src/sdk/composables/usePdkAdminApi.ts
@@ -16,7 +16,7 @@ export const usePdkAdminApi = createGlobalState((): MyParcelSdk<AbstractPdkEndpo
   });
 
   const pdkEndpoints = Object.entries(globalContext.endpoints).map(([endpointName, options]) => {
-    // Effectively cast null as 'undefined' to prevent the the SDK casting the prefix property to the string 'null'.
+    // Effectively cast null as 'undefined' to prevent the SDK casting the prefix property to the string 'null'.
     const property = typeof options.property === 'string' ? options.property : undefined;
     const responseProperty = typeof options.responseProperty === 'string' ? options.responseProperty : undefined;
     class PdkEndpoint extends AbstractPdkEndpoint {

--- a/apps/admin/src/sdk/composables/usePdkAdminApi.ts
+++ b/apps/admin/src/sdk/composables/usePdkAdminApi.ts
@@ -1,6 +1,6 @@
 import {createGlobalState} from '@vueuse/core';
-import {type BackendEndpoint} from '@myparcel-dev/pdk-common';
 import {createMyParcelSdk, type HttpMethod, type MyParcelSdk} from '@myparcel-dev/sdk';
+import {type BackendEndpoint} from '@myparcel-dev/pdk-common';
 import {AbstractPdkEndpoint} from '../endpoints';
 import {PdkFetchClient} from '../PdkFetchClient';
 import {useGlobalContext} from '../../composables';
@@ -16,12 +16,17 @@ export const usePdkAdminApi = createGlobalState((): MyParcelSdk<AbstractPdkEndpo
   });
 
   const pdkEndpoints = Object.entries(globalContext.endpoints).map(([endpointName, options]) => {
+    // Effectively cast null as 'undefined' to prevent the the SDK casting the prefix property to the string 'null'.
+    const property = typeof options.property === 'string' ? options.property : undefined;
+    const responseProperty = typeof options.responseProperty === 'string' ? options.responseProperty : undefined;
     class PdkEndpoint extends AbstractPdkEndpoint {
       public readonly method = options.method.toUpperCase() as HttpMethod;
       public readonly name = endpointName as BackendEndpoint;
       public readonly path = options.path;
-      public readonly property = options.property;
-      public readonly responseProperty = options.responseProperty ?? options.property;
+      public readonly property = property;
+      // SDK will use `options.property` as fallback if this is undefined.
+      public readonly responseProperty = responseProperty;
+      public readonly useDataEnvelope = typeof options.useDataEnvelope === 'undefined' ? true : options.useDataEnvelope;
     }
 
     return new PdkEndpoint({

--- a/apps/admin/src/sdk/composables/usePdkAdminApi.ts
+++ b/apps/admin/src/sdk/composables/usePdkAdminApi.ts
@@ -24,7 +24,7 @@ export const usePdkAdminApi = createGlobalState((): MyParcelSdk<AbstractPdkEndpo
       public readonly name = endpointName as BackendEndpoint;
       public readonly path = options.path;
       public readonly property = property;
-      // SDK will use `options.property` as fallback if this is undefined.
+      // If this is undefined, the SDK falls back to the endpoint instance's `property` value above.
       public readonly responseProperty = responseProperty;
       public readonly useDataEnvelope = typeof options.useDataEnvelope === 'undefined' ? true : options.useDataEnvelope;
     }

--- a/apps/admin/src/types/sdk.types.ts
+++ b/apps/admin/src/types/sdk.types.ts
@@ -1,3 +1,4 @@
+import {type RecursivePartial} from '@myparcel-dev/ts-utils';
 import {
   type AdminContextKey,
   type BackendEndpoint,
@@ -11,7 +12,6 @@ import {
   type Settings,
   type Shipment,
 } from '@myparcel-dev/pdk-common';
-import {type RecursivePartial} from '@myparcel-dev/ts-utils';
 import {type AdminContextObject} from './context.types';
 import {type WebhookDefinition} from './common.types';
 
@@ -192,11 +192,11 @@ interface ProxyCapabilitiesDefinition extends PdkEndpointDefinition {
    * Action-control parameters live in the query string so the request body stays a clean
    * mirror of the actual capabilities API contract.
    *
-   * `filterOptions` (opt-in): when `'true'`, the action applies the registered-option allowlist
+   * `filterSupported` (opt-in): when `'true'`, the action applies the registered-option allowlist
    * server-side (`Carrier::filterRegisteredOptions`). Absent / any other value preserves the
    * unfiltered SDK passthrough for existing callers.
    */
-  parameters?: {filterOptions?: 'true'};
+  parameters?: {filterSupported?: boolean};
   /**
    * Body shape mirrors the actual capabilities API request: camelCase keys at every level
    * matching the SDK's attribute maps (`countryCode`, `physicalProperties`, `packageType`,
@@ -228,7 +228,9 @@ interface ProxyCapabilitiesDefinition extends PdkEndpointDefinition {
  * change to the endpoint contract flows through automatically.
  */
 export type ProxyCapabilitiesBody = NonNullable<ProxyCapabilitiesDefinition['body']>;
+
 export type ProxyCapabilitiesParameters = NonNullable<ProxyCapabilitiesDefinition['parameters']>;
+
 export type ProxyCapabilitiesCall = (options: {
   body: ProxyCapabilitiesBody;
   parameters?: ProxyCapabilitiesParameters;

--- a/apps/admin/src/types/sdk.types.ts
+++ b/apps/admin/src/types/sdk.types.ts
@@ -192,9 +192,10 @@ interface ProxyCapabilitiesDefinition extends PdkEndpointDefinition {
    * Action-control parameters live in the query string so the request body stays a clean
    * mirror of the actual capabilities API contract.
    *
-   * `filterSupported` (opt-in): when `'true'`, the action applies the registered-option allowlist
-   * server-side (`Carrier::filterRegisteredOptions`). Absent / any other value preserves the
-   * unfiltered SDK passthrough for existing callers.
+   * `filterSupported` (opt-in): when `true`, the action applies the registered-option allowlist
+   * server-side (`Carrier::filterRegisteredOptions`). When `false` or `undefined`, the backend
+   * should treat it as not opted in, preserving the existing unfiltered SDK passthrough
+   * behavior for callers.
    */
   parameters?: {filterSupported?: boolean};
   /**

--- a/libs/common/src/types/php-pdk.types.ts
+++ b/libs/common/src/types/php-pdk.types.ts
@@ -107,8 +107,9 @@ export namespace Base {
     method: string;
     parameters: Record<string, string>;
     path: string;
-    property: string;
-    responseProperty?: string;
+    property?: string | null;
+    useDataEnvelope?: boolean;
+    responseProperty?: string | null;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2633,7 +2633,7 @@ __metadata:
     "@myparcel-dev/constants": "npm:^2.9.0"
     "@myparcel-dev/pdk-build-vite": "workspace:*"
     "@myparcel-dev/pdk-common": "workspace:^1.12.0"
-    "@myparcel-dev/sdk": "npm:^5.0.0"
+    "@myparcel-dev/sdk": "npm:^5.1.0"
     "@myparcel-dev/vue-form-builder": "npm:1.0.0-beta.42.6"
     "@tanstack/vue-query": "npm:~4.43.0"
     "@types/lodash-es": "npm:^4.17.6"
@@ -2850,6 +2850,16 @@ __metadata:
     "@myparcel-dev/constants": "npm:^2.7.0"
     "@myparcel-dev/ts-utils": "npm:^1.15.0"
   checksum: 10c0/e7fb382eae6a689edac96e34e1483aa5a7b99353f3ea2019439cd322447b6642203251af50e9bfc327183a94c2e3d2fa9a6a2e9bcb713af3cdd6a5e79a3d8850
+  languageName: node
+  linkType: hard
+
+"@myparcel-dev/sdk@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@myparcel-dev/sdk@npm:5.1.0"
+  dependencies:
+    "@myparcel-dev/constants": "npm:^2.7.0"
+    "@myparcel-dev/ts-utils": "npm:^1.15.0"
+  checksum: 10c0/c518a06b3c54827bdcf8e22418ef844c3bc1490a52086a612d7576ba4561488aa512b4aed37dbbb9ccdb65f060edf5232e0905b4980ddd8b4c1bb1cf6fec2630
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump `@myparcel-dev/sdk` to ^5.1.0
- Rename `filterOptions: 'true'` to `filterSupported: boolean` on the proxyCapabilities params (matches the new SDK action contract); both order- and shipment-scoped queries now opt in
- Wire `useDataEnvelope` through `PdkEndpoint` so endpoints opting out skip the `{data: …}` wrapper
- Coerce nullish `property` / `responseProperty` to `undefined` so the SDK's `i === void 0` check fires correctly (avoids the `"null"` string-key footgun when PHP sends `null`)
- Loosen the `Base` endpoint type in `php-pdk.types.ts` to allow nullable / optional `property` + `responseProperty` and the new `useDataEnvelope` flag

## Test plan
- [ ] Open an order in WC admin, confirm shipment-options form loads and renders carrier/package/delivery dropdowns
- [ ] Pick a carrier + package + delivery type and verify the proxyCapabilities request body is `{data: {capabilities: {…}}}` and the query string carries `filterSupported=true`
- [ ] Confirm form options are correctly filtered/clear on invalid combos

Resolves INT-1553