### PR TITLE
feat(admin): read default carrier from shop instead of proposition

### DIFF
--- a/apps/admin/src/__tests__/mocks/mockDefaultProposition.ts
+++ b/apps/admin/src/__tests__/mocks/mockDefaultProposition.ts
@@ -4,7 +4,6 @@ import {type GlobalAdminContext} from '../../types';
 export const mockDefaultProposition = vi.fn((): GlobalAdminContext['proposition'] => {
   return {
     backofficeUrl: 'https://backoffice.test.myparcel.nl',
-    defaultCarrier: 'POSTNL',
     human: 'Test',
     localCountry: 'NL',
     name: 'test',

--- a/apps/admin/src/__tests__/mocks/mockDefaultShop.ts
+++ b/apps/admin/src/__tests__/mocks/mockDefaultShop.ts
@@ -16,5 +16,6 @@ export const mockDefaultShop = vi.fn((): Account.ModelShop => {
     hidden: false,
     shipmentOptions: {},
     trackTrace: {},
+    defaultCarrier: 'POSTNL',
   };
 });

--- a/apps/admin/src/forms/shipmentOptions/fields/createCarrierField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createCarrierField.ts
@@ -18,7 +18,7 @@ import {type RadioGroupOption} from '../../../types';
 import {useQueryStore} from '../../../stores';
 import {useFetchCarrier} from '../../../sdk';
 import {AdminComponent} from '../../../data';
-import {useContext, useGlobalContext, useLanguage} from '../../../composables';
+import {useContext, useLanguage} from '../../../composables';
 import {createRef} from './createRef';
 
 type CarrierMeta = {label: string; image?: string};
@@ -103,7 +103,7 @@ export const createCarrierField = (
   return defineFormField({
     name: FIELD_CARRIER,
     label: 'carrier',
-    ref: createRef<string>(refs, FIELD_CARRIER, useGlobalContext().proposition.defaultCarrier),
+    ref: createRef<string>(refs, FIELD_CARRIER, dynamicContext.shop.defaultCarrier ?? undefined),
     component: resolveFormComponent(AdminComponent.RadioGroup),
     props: {
       options: [],

--- a/apps/backend-demo/data/db/context/dynamic.json
+++ b/apps/backend-demo/data/db/context/dynamic.json
@@ -322,7 +322,8 @@
           }
         }
       ],
-      "carrierConfigurations": []
+      "carrierConfigurations": [],
+      "defaultCarrier": "POSTNL"
     }
   }
 }

--- a/apps/backend-demo/data/db/context/global.json
+++ b/apps/backend-demo/data/db/context/global.json
@@ -228,9 +228,7 @@
       "human": "MyParcel",
       "supportUrl": "https://developer.myparcel.nl/contact",
       "backofficeUrl": "https://backoffice.myparcel.nl",
-      "localCountry": "NL",
-      "defaultCarrier": "postnl",
-      "defaultCarrierId": 1
+      "localCountry": "NL"
     },
     "translations": {
       "apple_tree": "Appelboom"

--- a/libs/common/src/types/php-pdk.types.ts
+++ b/libs/common/src/types/php-pdk.types.ts
@@ -54,6 +54,7 @@ export namespace Account {
     trackTrace: Record<string, unknown>;
     carrierConfigurations: ShopCarrierConfigurationCollection;
     carriers: CarrierCollection;
+    defaultCarrier: string | null;
   };
 
   export type ModelShopCarrierConfiguration = {
@@ -374,7 +375,6 @@ export namespace Plugin {
       backofficeUrl: string;
       supportUrl: string;
       localCountry: string;
-      defaultCarrier: string;
     };
     translations: Record<string, string>;
   };


### PR DESCRIPTION
## Summary

Migrate to `shop.defaultCarrier` following the PDK refactor that removed `proposition.defaultCarrier`. The default carrier now lives on the Shop model — populated from the CoreAPI shipping-rules implications endpoint — rather than baked into proposition config.

## Companion

Stacked on top of [myparcelnl/pdk#472 (INT-1479)](https://github.com/myparcelnl/pdk/pull/472), which removes `proposition.defaultCarrier` from the PDK's GlobalContext payload and exposes `defaultCarrier` on the Shop model instead.

Because js-pdk-admin is the shared admin frontend for both plugins, this PR is a prerequisite for both [myparcelnl/prestashop#524 (INT-1589)](https://github.com/myparcelnl/prestashop/pull/524) and the WooCommerce side (INT-1588 — likely just a dependency bump once this and the PDK PR are released).

This PR targets `capabilities` to match the PDK PR's target. All three (PDK, js-pdk, prestashop) flip to ready after the SDK release for [myparcelnl/pdk#471 (INT-1586)](https://github.com/myparcelnl/pdk/pull/471) ships.

## Changes

- Add `defaultCarrier: string | null` to `Account.ModelShop` type.
- Drop `defaultCarrier: string` from `ModelContextGlobalContext.proposition`.
- `createCarrierField` now reads `dynamicContext.shop.defaultCarrier` as the form field's initial value (with `?? undefined` so a null default falls through to whatever the field handles for "no default").
- `mockDefaultProposition` drops the field; `mockDefaultShop` adds it.
- Backend-demo fixtures move the field from `global.platform` to `dynamic.shop`.

## Test plan

- [x] `yarn nx run @myparcel-dev/pdk-common:build` — types build clean.
- [x] `yarn nx run @myparcel-dev/pdk-admin:build` — admin app builds clean.
- [ ] Unit tests: 3 pre-existing failures unrelated to this change (`createShipmentOptionsForm.spec.ts` MagicForm mock issue + 2 `exports.spec.ts` snapshot drifts). All tests touching `createCarrierField` or `proposition.defaultCarrier` pass.
- [ ] After PDK PR merges: manual smoke test against backend-demo — confirm the admin shipment options form's carrier field defaults to the shop's stored carrier.

Refs INT-1479
Refs INT-1588
Refs INT-1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)