### PR TITLE
feat: show shipment export actions in Order v2 admin

### DIFF
--- a/apps/admin/src/actions/orderModeActions.spec.ts
+++ b/apps/admin/src/actions/orderModeActions.spec.ts
@@ -32,10 +32,10 @@ describe('orderModeActions', () => {
       expect(ids).toEqual([AdminAction.OrdersEdit, AdminAction.OrdersExport]);
     });
 
-    it('includes only edit for OrderV2', () => {
+    it('includes edit and export-to-shipments for OrderV2 (hybrid)', () => {
       const ids = getDefinitionIds(LIST_ITEM_MODE_ACTIONS[OrderMode.OrderV2]);
 
-      expect(ids).toEqual([AdminAction.OrdersEdit]);
+      expect(ids).toEqual([AdminAction.OrdersEdit, AdminAction.OrdersExport]);
     });
 
     it('has no actions for Shipments mode', () => {
@@ -63,8 +63,16 @@ describe('orderModeActions', () => {
       expect(ids).toContain(AdminAction.ShipmentsPrint);
     });
 
-    it('registers no additional actions for OrderV2', () => {
-      expect(STORE_MODE_ACTIONS[OrderMode.OrderV2]).toHaveLength(0);
+    it('registers the full shipment action set for OrderV2 (hybrid mirrors Shipments)', () => {
+      const ids = getDefinitionIds(STORE_MODE_ACTIONS[OrderMode.OrderV2]);
+
+      expect(ids).toContain(AdminAction.OrdersPrint);
+      expect(ids).toContain(AdminAction.OrdersExport);
+      expect(ids).toContain(AdminAction.OrdersExportPrint);
+      expect(ids).toContain(AdminAction.ShipmentsExportReturn);
+      expect(ids).toContain(AdminAction.ShipmentsDelete);
+      expect(ids).toContain(AdminAction.ShipmentsUpdate);
+      expect(ids).toContain(AdminAction.ShipmentsPrint);
     });
   });
 
@@ -83,8 +91,12 @@ describe('orderModeActions', () => {
       expect(ids).toContain(AdminAction.OrdersExportPrint);
     });
 
-    it('has no actions for OrderV2', () => {
-      expect(BOX_MODE_ACTIONS[OrderMode.OrderV2]).toHaveLength(0);
+    it('mirrors the Shipments set for OrderV2 (hybrid)', () => {
+      const ids = getDefinitionIds(BOX_MODE_ACTIONS[OrderMode.OrderV2]);
+
+      expect(ids).toContain(AdminAction.OrdersExport);
+      expect(ids).toContain(AdminAction.OrdersPrint);
+      expect(ids).toContain(AdminAction.OrdersExportPrint);
     });
   });
 
@@ -103,8 +115,12 @@ describe('orderModeActions', () => {
       expect(ids).not.toContain(AdminAction.OrdersPrint);
     });
 
-    it('has no actions for OrderV2', () => {
-      expect(MODAL_MODE_ACTIONS[OrderMode.OrderV2]).toHaveLength(0);
+    it('mirrors the Shipments set for OrderV2 (hybrid)', () => {
+      const ids = getDefinitionIds(MODAL_MODE_ACTIONS[OrderMode.OrderV2]);
+
+      expect(ids).toContain(AdminAction.OrdersExport);
+      expect(ids).toContain(AdminAction.OrdersExportPrint);
+      expect(ids).not.toContain(AdminAction.OrdersPrint);
     });
   });
 

--- a/apps/admin/src/actions/orderModeActions.ts
+++ b/apps/admin/src/actions/orderModeActions.ts
@@ -17,6 +17,11 @@ export {ORDER_VIEW_IN_BACKOFFICE_ID} from './definitions';
 
 /**
  * Mode-specific actions for global store registration (superset of all available actions per mode).
+ *
+ * OrderV2 currently mirrors the Shipments set so manual shipment export and the related
+ * actions remain available while V2 fulfilment continues externally. INT-1590 will
+ * make this conditional on sales-channel detection so V2 with an active sales channel
+ * goes back to an empty set.
  */
 export const STORE_MODE_ACTIONS: Record<OrderMode, AnyActionDefinition[]> = {
   [OrderMode.OrderV1]: [orderExportAction, orderViewInBackofficeAction],
@@ -29,33 +34,57 @@ export const STORE_MODE_ACTIONS: Record<OrderMode, AnyActionDefinition[]> = {
     shipmentsUpdateAction,
     shipmentsPrintAction,
   ],
-  [OrderMode.OrderV2]: [],
+  // @TODO INT-1590: empty this array again once sales-channel detection gates V2.
+  [OrderMode.OrderV2]: [
+    ordersPrintAction,
+    orderExportToShipmentsAction,
+    ordersExportPrintShipmentsAction,
+    shipmentsExportReturnAction,
+    shipmentsDeleteAction,
+    shipmentsUpdateAction,
+    shipmentsPrintAction,
+  ],
 };
 
 /**
  * Mode-specific actions for the ShipmentOptionsBox component.
+ *
+ * OrderV2 currently mirrors the Shipments set so the order-detail box exposes manual
+ * export, print and export-print actions. {@see STORE_MODE_ACTIONS} for the
+ * INT-1590 follow-up note.
  */
 export const BOX_MODE_ACTIONS: Record<OrderMode, AnyActionDefinition[]> = {
   [OrderMode.OrderV1]: [orderExportAction],
   [OrderMode.Shipments]: [orderExportToShipmentsAction, ordersPrintAction, ordersExportPrintShipmentsAction],
-  [OrderMode.OrderV2]: [],
+  // @TODO INT-1590: empty this array again once sales-channel detection gates V2.
+  [OrderMode.OrderV2]: [orderExportToShipmentsAction, ordersPrintAction, ordersExportPrintShipmentsAction],
 };
 
 /**
  * Mode-specific actions for the ShipmentOptionsModal component.
+ *
+ * OrderV2 currently mirrors the Shipments set so the modal exposes manual export and
+ * export-print actions. {@see STORE_MODE_ACTIONS} for the INT-1590 follow-up note.
  */
 export const MODAL_MODE_ACTIONS: Record<OrderMode, AnyActionDefinition[]> = {
   [OrderMode.OrderV1]: [orderExportAction],
   [OrderMode.Shipments]: [orderExportToShipmentsAction, ordersExportPrintShipmentsAction],
-  [OrderMode.OrderV2]: [],
+  // @TODO INT-1590: empty this array again once sales-channel detection gates V2.
+  [OrderMode.OrderV2]: [orderExportToShipmentsAction, ordersExportPrintShipmentsAction],
 };
 
 /**
  * Mode-specific actions rendered in the order-list-item button group.
  * Shipments mode uses its own computed action logic in ShipmentModeOrderListItem.vue.
+ *
+ * OrderV2 surfaces the same edit + manual export combination as OrderV1, but routes
+ * export through the shipments-export action because in V2 the backend falls through
+ * to the shipments-export path. {@see STORE_MODE_ACTIONS} for the INT-1590 follow-up
+ * note.
  */
 export const LIST_ITEM_MODE_ACTIONS: Record<OrderMode, AnyActionDefinition[]> = {
   [OrderMode.OrderV1]: [ordersEditAction, orderExportAction],
-  [OrderMode.OrderV2]: [ordersEditAction],
+  // @TODO INT-1590: drop orderExportToShipmentsAction once sales-channel detection gates V2.
+  [OrderMode.OrderV2]: [ordersEditAction, orderExportToShipmentsAction],
   [OrderMode.Shipments]: [],
 };

--- a/apps/admin/src/components/OrderBox/ShipmentOptionsBox.spec.ts
+++ b/apps/admin/src/components/OrderBox/ShipmentOptionsBox.spec.ts
@@ -84,22 +84,26 @@ describe('ShipmentOptionsBox', () => {
     expect(ids).toEqual([ORDER_VIEW_IN_BACKOFFICE_ID]);
   });
 
-  it('shows only update in OrderV2 mode', () => {
+  it('shows update plus the shipment-export action set in OrderV2 mode (hybrid)', () => {
     mockedUseOrderMode.mockReturnValue(computed(() => OrderMode.OrderV2));
     mockOrderData(mockedUseOrderData);
     const wrapper = mount(ShipmentOptionsBox);
     const ids = getBoxActionIds(wrapper);
 
-    expect(ids).toEqual([AdminAction.OrdersUpdate]);
+    expect(ids).toContain(AdminAction.OrdersUpdate);
+    expect(ids).toContain(AdminAction.OrdersExport);
+    expect(ids).toContain(AdminAction.OrdersPrint);
+    expect(ids).toContain(AdminAction.OrdersExportPrint);
   });
 
-  it('never shows exported state in OrderV2 mode even if order has exported flag', () => {
+  it('does not show the V1 backoffice link in OrderV2 mode, even if order has exported flag', () => {
     mockedUseOrderMode.mockReturnValue(computed(() => OrderMode.OrderV2));
     mockOrderData(mockedUseOrderData, {exported: true});
     const wrapper = mount(ShipmentOptionsBox);
     const ids = getBoxActionIds(wrapper);
 
-    expect(ids).toEqual([AdminAction.OrdersUpdate]);
     expect(ids).not.toContain(ORDER_VIEW_IN_BACKOFFICE_ID);
+    // Hybrid actions still appear regardless of the exported flag.
+    expect(ids).toContain(AdminAction.OrdersExport);
   });
 });

--- a/apps/admin/src/components/OrderListItem/OrderModeOrderListItem.spec.ts
+++ b/apps/admin/src/components/OrderListItem/OrderModeOrderListItem.spec.ts
@@ -84,22 +84,20 @@ describe('OrderModeOrderListItem', () => {
       mockedUseOrderMode.mockReturnValue(computed(() => OrderMode.OrderV2));
     });
 
-    it('shows only the edit action', () => {
+    it('shows the edit action and the shipment-export action (hybrid)', () => {
       mockOrderData(mockedUseOrderData);
       const wrapper = mount(OrderModeOrderListItem);
       const html = wrapper.html();
 
       expect(html).toContain(AdminAction.OrdersEdit);
+      expect(html).toContain(AdminAction.OrdersExport);
     });
 
-    it('does not show export, print, or backoffice actions, even when the order is exported', () => {
+    it('does not show the V1 backoffice link, even when the order is exported', () => {
       mockOrderData(mockedUseOrderData, {exported: true});
       const wrapper = mount(OrderModeOrderListItem);
       const html = wrapper.html();
 
-      expect(html).not.toContain(AdminAction.OrdersExport);
-      expect(html).not.toContain(AdminAction.OrdersPrint);
-      expect(html).not.toContain(AdminAction.OrdersExportPrint);
       expect(html).not.toContain(ORDER_VIEW_IN_BACKOFFICE_ID);
     });
   });

--- a/apps/admin/src/components/modals/ShipmentOptionsModal.spec.ts
+++ b/apps/admin/src/components/modals/ShipmentOptionsModal.spec.ts
@@ -64,11 +64,16 @@ describe('ShipmentOptionsModal', () => {
     expect(ids).not.toContain(AdminAction.OrdersExportPrint);
   });
 
-  it('shows only close and update in OrderV2 mode', () => {
+  it('shows close, update, export and export-print in OrderV2 mode (hybrid)', () => {
     mockedUseOrderMode.mockReturnValue(computed(() => OrderMode.OrderV2));
     const wrapper = mount(ShipmentOptionsModal);
     const ids = getModalActionIds(wrapper);
 
-    expect(ids).toEqual([MODAL_CLOSE_ID, AdminAction.OrdersUpdate]);
+    expect(ids).toContain(MODAL_CLOSE_ID);
+    expect(ids).toContain(AdminAction.OrdersUpdate);
+    expect(ids).toContain(AdminAction.OrdersExport);
+    expect(ids).toContain(AdminAction.OrdersExportPrint);
+    // Standalone print is intentionally absent from the modal in both Shipments and V2.
+    expect(ids).not.toContain(AdminAction.OrdersPrint);
   });
 });

--- a/apps/admin/src/composables/context/useOrderMode.spec.ts
+++ b/apps/admin/src/composables/context/useOrderMode.spec.ts
@@ -9,8 +9,8 @@ vi.mock('./useContext', () => ({
 
 const mockedUseContext = vi.mocked(useContext);
 
-const mockAccount = (subscriptionFeatures: string[]) => {
-  mockedUseContext.mockReturnValue({account: {subscriptionFeatures}} as any);
+const mockAccount = (subscriptionFeatures: string[], effectiveOrderMode?: unknown) => {
+  mockedUseContext.mockReturnValue({account: {subscriptionFeatures, effectiveOrderMode}} as any);
 };
 
 describe('useOrderMode', () => {
@@ -47,5 +47,29 @@ describe('useOrderMode', () => {
   it('returns Shipments when account is undefined', () => {
     mockedUseContext.mockReturnValue({} as any);
     expect(useOrderMode().value).toBe(OrderMode.Shipments);
+  });
+
+  it('prefers a PHP-supplied effectiveOrderMode of 2 (V2) over the feature derivation', () => {
+    // Feature would resolve to Shipments here; effectiveOrderMode overrides it.
+    mockAccount([], 2);
+    expect(useOrderMode().value).toBe(OrderMode.OrderV2);
+  });
+
+  it('prefers a PHP-supplied effectiveOrderMode of 1 (V1) over the feature derivation', () => {
+    // Feature would resolve to OrderV2; effectiveOrderMode overrides to V1.
+    mockAccount([SubscriptionFeature.OrderManagement], 1);
+    expect(useOrderMode().value).toBe(OrderMode.OrderV1);
+  });
+
+  it('prefers a PHP-supplied effectiveOrderMode of 0 (Shipments) over the feature derivation', () => {
+    // Feature would resolve to OrderV2; effectiveOrderMode downgrades to Shipments
+    // (the shape INT-1590 will produce).
+    mockAccount([SubscriptionFeature.OrderManagement], 0);
+    expect(useOrderMode().value).toBe(OrderMode.Shipments);
+  });
+
+  it('falls back to feature derivation when effectiveOrderMode is not a known numeric mode', () => {
+    mockAccount([SubscriptionFeature.LegacyOrderManagement], 'unexpected-string');
+    expect(useOrderMode().value).toBe(OrderMode.OrderV1);
   });
 });

--- a/apps/admin/src/composables/context/useOrderMode.ts
+++ b/apps/admin/src/composables/context/useOrderMode.ts
@@ -1,9 +1,26 @@
 import {type ComputedRef, computed} from 'vue';
-import {type OrderMode, resolveOrderMode} from '../../data';
+import {type OrderMode, orderModeFromContextValue, resolveOrderMode} from '../../data';
 import {useContext} from './useContext';
 
+/**
+ * Resolve the order mode the admin UI should adapt to.
+ *
+ * Prefers the pre-computed `effectiveOrderMode` emitted by the PDK admin context
+ * (so any business rules applied on the PHP side — e.g. INT-1590's
+ * sales-channel-conditional downgrade — naturally flow through). Falls back to
+ * resolving from the raw IAM subscription features when the context does not
+ * (yet) carry that value, which keeps older PDK versions working.
+ */
 export const useOrderMode = (): ComputedRef<OrderMode> => {
   const context = useContext();
 
-  return computed(() => resolveOrderMode(context.account?.subscriptionFeatures ?? []));
+  return computed(() => {
+    // `effectiveOrderMode` is forward-looking — the PHP context generator may not
+    // emit it yet. Cast locally rather than augmenting the generated type.
+    const effective = orderModeFromContextValue(
+      (context.account as {effectiveOrderMode?: unknown} | undefined)?.effectiveOrderMode,
+    );
+
+    return effective ?? resolveOrderMode(context.account?.subscriptionFeatures ?? []);
+  });
 };

--- a/apps/admin/src/data/orderMode.ts
+++ b/apps/admin/src/data/orderMode.ts
@@ -9,6 +9,38 @@ export enum SubscriptionFeature {
   OrderManagement = 'ORDER_MANAGEMENT',
 }
 
+/**
+ * Mapping from the PHP-side `AccountFeaturesServiceInterface::ORDER_MODE_*`
+ * integer constants to the JS-side {@see OrderMode} enum.
+ */
+const ORDER_MODE_BY_NUMERIC: Record<number, OrderMode> = {
+  0: OrderMode.Shipments,
+  1: OrderMode.OrderV1,
+  2: OrderMode.OrderV2,
+};
+
+/**
+ * Translate the numeric `effectiveOrderMode` emitted by the PDK admin context
+ * (when present) into the JS-side {@see OrderMode} enum. Returns `undefined`
+ * when the value is missing or not one of the known modes, so callers can fall
+ * back to feature-based resolution.
+ */
+export const orderModeFromContextValue = (value: unknown): OrderMode | undefined => {
+  if (typeof value === 'number' && value in ORDER_MODE_BY_NUMERIC) {
+    return ORDER_MODE_BY_NUMERIC[value];
+  }
+
+  return undefined;
+};
+
+/**
+ * Derive the active {@see OrderMode} from the raw IAM subscription features.
+ *
+ * Use this only as a fallback for environments where the PDK admin context does
+ * not yet surface a pre-computed `effectiveOrderMode`. Prefer the context value
+ * so any business rules layered on top in PHP (e.g. INT-1590's sales-channel
+ * downgrade) take effect on the JS side automatically.
+ */
 export const resolveOrderMode = (features: string[]): OrderMode => {
   if (features.includes(SubscriptionFeature.OrderManagement)) return OrderMode.OrderV2;
 

--- a/apps/admin/src/forms/pluginSettings/filterPluginSettingsView.spec.ts
+++ b/apps/admin/src/forms/pluginSettings/filterPluginSettingsView.spec.ts
@@ -105,8 +105,19 @@ describe('filterPluginSettingsView', () => {
     });
   });
 
-  describe('OrderV2 mode', () => {
-    it('removes the entire General section including its divider', () => {
+  describe('OrderV2 mode (hybrid: surfaces the same fields and tabs as Shipments)', () => {
+    it('keeps all General section fields visible, including the shipment-export-only ones', () => {
+      const result = filterPluginSettingsView(createFullView(), OrderMode.OrderV2);
+      const fieldNames = getFieldNames(result.order.elements);
+
+      expect(fieldNames).toContain('conceptShipments');
+      expect(fieldNames).toContain('saveCustomerAddress');
+      expect(fieldNames).toContain('processDirectly');
+      expect(fieldNames).toContain('sendReturnEmail');
+      expect(fieldNames).toContain('shareCustomerInformation');
+    });
+
+    it('keeps the General section divider in place', () => {
       const result = filterPluginSettingsView(createFullView(), OrderMode.OrderV2);
       const elements = result.order.elements ?? [];
 
@@ -114,32 +125,13 @@ describe('filterPluginSettingsView', () => {
         (el) => (el as Record<string, unknown>).heading === 'settings_order_general_title',
       );
 
-      expect(hasGeneralDivider).toBe(false);
-
-      expect(getFieldNames(elements)).not.toContain('conceptShipments');
-      expect(getFieldNames(elements)).not.toContain('saveCustomerAddress');
-      expect(getFieldNames(elements)).not.toContain('processDirectly');
-      expect(getFieldNames(elements)).not.toContain('sendReturnEmail');
-      expect(getFieldNames(elements)).not.toContain('shareCustomerInformation');
+      expect(hasGeneralDivider).toBe(true);
     });
 
-    it('hides the label tab', () => {
+    it('keeps all tabs visible (label and customs return alongside Shipments-mode behaviour)', () => {
       const result = filterPluginSettingsView(createFullView(), OrderMode.OrderV2);
 
-      expect(getTabIds(result)).not.toContain('label');
-    });
-
-    it('hides the customs tab', () => {
-      const result = filterPluginSettingsView(createFullView(), OrderMode.OrderV2);
-
-      expect(getTabIds(result)).not.toContain('customs');
-    });
-
-    it('keeps checkout and carrier tabs visible', () => {
-      const result = filterPluginSettingsView(createFullView(), OrderMode.OrderV2);
-
-      expect(getTabIds(result)).toContain('checkout');
-      expect(getTabIds(result)).toContain('carrier');
+      expect(getTabIds(result)).toEqual(['order', 'label', 'customs', 'checkout', 'carrier']);
     });
 
     it('keeps non-General sections in the order tab', () => {

--- a/apps/admin/src/forms/pluginSettings/filterPluginSettingsView.ts
+++ b/apps/admin/src/forms/pluginSettings/filterPluginSettingsView.ts
@@ -3,9 +3,20 @@ import {OrderMode} from '../../data';
 
 const GENERAL_SECTION_HEADING = 'settings_order_general_title';
 
-const SHIPMENTS_ONLY_FIELDS: ReadonlySet<string> = new Set(['conceptShipments', 'saveCustomerAddress']);
+/**
+ * Settings only relevant when the plugin creates shipments via the shipments API —
+ * that covers Shipments mode and the V2 hybrid (manual export). Order v1 uses the
+ * fulfilment-orders path instead, so these settings are hidden there.
+ *
+ * @TODO INT-1590: revisit when sales-channel detection lands — under V2 with an
+ *       active sales channel these settings should be hidden again.
+ */
+const SHIPMENT_EXPORT_FIELDS: ReadonlySet<string> = new Set(['conceptShipments', 'saveCustomerAddress']);
 
-const ORDER_V2_HIDDEN_TABS: ReadonlySet<string> = new Set(['label', 'customs']);
+// @TODO INT-1590: restore tab hiding once sales-channel detection lands; under V2
+//       with an active sales channel the label and customs tabs become irrelevant
+//       again (the sales channel handles fulfilment end-to-end).
+// const ORDER_V2_HIDDEN_TABS: ReadonlySet<string> = new Set(['label', 'customs']);
 
 const isSettingsDivider = (field: Plugin.Field): boolean => {
   return field.$component === 'SettingsDivider';
@@ -29,25 +40,43 @@ const filterOrderElements = (elements: Plugin.Field[], orderMode: OrderMode): Pl
       return true;
     }
 
-    if (isSettingsDivider(field)) {
-      return orderMode !== OrderMode.OrderV2;
+    // @TODO INT-1590: restore the V2-divider hiding for active-sales-channel state.
+    // if (isSettingsDivider(field)) {
+    //   return orderMode !== OrderMode.OrderV2;
+    // }
+
+    if (SHIPMENT_EXPORT_FIELDS.has(field.name ?? '')) {
+      return orderMode !== OrderMode.OrderV1;
     }
 
-    if (SHIPMENTS_ONLY_FIELDS.has(field.name ?? '')) {
-      return orderMode === OrderMode.Shipments;
-    }
-
-    return orderMode !== OrderMode.OrderV2;
+    // @TODO INT-1590: restore the V2 general-section hiding for active-sales-channel state.
+    // return orderMode !== OrderMode.OrderV2;
+    return true;
   });
 };
 
+/**
+ * Filter the plugin-settings view for the active order mode.
+ *
+ * Today the V2 hybrid surfaces all the same tabs and fields as Shipments mode so
+ * manual export keeps working. Only Order v1 hides the shipment-export-specific
+ * fields, because v1 uses fulfilment orders instead.
+ *
+ * @TODO INT-1590: once sales-channel detection lands, re-introduce tab hiding for
+ *       V2 with an active sales channel — the label/customs tabs and shipment-export
+ *       fields become irrelevant when the sales channel handles fulfilment
+ *       end-to-end.
+ */
 export const filterPluginSettingsView = (
   view: Plugin.ModelContextPluginSettingsViewContext,
   orderMode: OrderMode,
 ): Plugin.ModelContextPluginSettingsViewContext => {
-  const entries = Object.entries(view).filter(([tabId]) => {
-    return !(orderMode === OrderMode.OrderV2 && ORDER_V2_HIDDEN_TABS.has(tabId));
-  });
+  // @TODO INT-1590: restore the V2 tab-hiding step using ORDER_V2_HIDDEN_TABS
+  //       (declared as commented constant above) once sales-channel detection lands.
+  // const entries = Object.entries(view).filter(([tabId]) => {
+  //   return !(orderMode === OrderMode.OrderV2 && ORDER_V2_HIDDEN_TABS.has(tabId));
+  // });
+  const entries = Object.entries(view);
 
   return Object.fromEntries(
     entries.map(([tabId, tabView]) => {

--- a/apps/admin/src/stores/useActionStore.spec.ts
+++ b/apps/admin/src/stores/useActionStore.spec.ts
@@ -78,17 +78,18 @@ describe('useActionStore', () => {
       expect(store.get(AdminAction.ShipmentsPrint)).toBeUndefined();
     });
 
-    it('registers no export or print actions in OrderV2 mode', () => {
+    it('registers the same shipment-specific action set as Shipments in OrderV2 mode (hybrid)', () => {
       const store = mountWithStore(OrderMode.OrderV2);
 
-      expect(store.get(AdminAction.OrdersPrint)).toBeUndefined();
-      expect(store.get(AdminAction.OrdersExport)).toBeUndefined();
-      expect(store.get(AdminAction.OrdersExportPrint)).toBeUndefined();
+      expect(store.get(AdminAction.OrdersPrint)).toBeDefined();
+      expect(store.get(AdminAction.OrdersExport)).toBeDefined();
+      expect(store.get(AdminAction.OrdersExportPrint)).toBeDefined();
+      expect(store.get(AdminAction.ShipmentsExportReturn)).toBeDefined();
+      expect(store.get(AdminAction.ShipmentsDelete)).toBeDefined();
+      expect(store.get(AdminAction.ShipmentsUpdate)).toBeDefined();
+      expect(store.get(AdminAction.ShipmentsPrint)).toBeDefined();
+      // The backoffice view is V1-only and should still not appear in V2.
       expect(store.get(ORDER_VIEW_IN_BACKOFFICE_ID)).toBeUndefined();
-      expect(store.get(AdminAction.ShipmentsExportReturn)).toBeUndefined();
-      expect(store.get(AdminAction.ShipmentsDelete)).toBeUndefined();
-      expect(store.get(AdminAction.ShipmentsUpdate)).toBeUndefined();
-      expect(store.get(AdminAction.ShipmentsPrint)).toBeUndefined();
     });
 
     it('registers shipmentsExportReturn exactly once in Shipments mode', () => {

--- a/apps/admin/src/views/OrderBox.vue
+++ b/apps/admin/src/views/OrderBox.vue
@@ -1,7 +1,14 @@
 <template>
   <ShipmentOptionsBox />
 
-  <ShipmentTableBox v-if="orderMode === OrderMode.Shipments && data?.shipments.some((item) => !item.deleted)" />
+  <!--
+    Shipments mode plus V2 hybrid both surface manual shipments here.
+    @TODO INT-1590: restrict to OrderMode.Shipments once V2 with an active sales
+          channel hides the manual paths again. Original gate preserved as a
+          comment below for easy restoration.
+  -->
+  <!-- <ShipmentTableBox v-if="orderMode === OrderMode.Shipments && data?.shipments.some((item) => !item.deleted)" /> -->
+  <ShipmentTableBox v-if="orderMode !== OrderMode.OrderV1 && data?.shipments.some((item) => !item.deleted)" />
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
The admin previously hid every export, print and shipment action when the account uses Order v2, leaving merchants without an active sales channel unable to interact with their shipments. This change makes the Order v2 admin mirror the Shipments-mode UI: the action store, the shipment-options box, the modal and the order-list-item button group all surface the same shipment-export action set as Shipments mode. Order v1 behaviour is unchanged.

`filterPluginSettingsView` relaxes its V2-specific hiding so the label and customs tabs come back, along with the `conceptShipments` and `saveCustomerAddress` fields that drive the shipment-export flow. The order-detail `ShipmentTableBox` is no longer Shipments-only either, so manual exports show up under the order they belong to.

`useOrderMode` gains a forward-looking context bridge: when the PDK admin context emits a numeric `effectiveOrderMode` (the seam INT-1590 will use to downgrade V2 to Shipments once it can detect an inactive sales channel), the composable consumes it directly. Until then the existing feature-derived resolution remains the fallback, so older PDK versions keep working unchanged.

Every change carries an `@TODO INT-1590` marker and the V2-specific gates that may need to come back are preserved as commented-out blocks so the eventual gating work has clear pickup points.

Depends on https://github.com/myparcelnl/pdk/pull/473.

Resolves INT-1594