### PR TITLE
fix(checkout-separate-address-fields): prevent and correct autofill of full address into street name field

### DIFF
--- a/libs/checkout-common/src/utils/global/setFieldValue.ts
+++ b/libs/checkout-common/src/utils/global/setFieldValue.ts
@@ -13,6 +13,7 @@ export const setFieldValue = (
 
   if (field) {
     field.value = value ?? '';
+    field.dispatchEvent(new Event('input', {bubbles: true}));
 
     if (dispatchEvent) {
       const triggerEvent = useUtil(PdkUtil.TriggerEvent);

--- a/libs/checkout-separate-address-fields/src/listeners/fillSeparateAddressFields.ts
+++ b/libs/checkout-separate-address-fields/src/listeners/fillSeparateAddressFields.ts
@@ -1,4 +1,5 @@
 import {isOfType} from '@myparcel-dev/ts-utils';
+import {type AddressType} from '@myparcel-dev/pdk-checkout-common';
 import {fillAddressFields, splitFullStreet} from '../utils';
 
 /**
@@ -6,11 +7,12 @@ import {fillAddressFields, splitFullStreet} from '../utils';
  * Split street to 3 fields on autofill.
  *
  * @param {Event} event
+ * @param {AddressType} [addressType]
  */
-export const fillSeparateAddressFields = (event: Event): void => {
+export const fillSeparateAddressFields = (event: Event, addressType?: AddressType): void => {
   if (!isOfType<HTMLInputElement>(event.target, 'value')) {
     return;
   }
 
-  fillAddressFields(splitFullStreet(event.target.value));
+  fillAddressFields(splitFullStreet(event.target.value), addressType);
 };

--- a/libs/checkout-separate-address-fields/src/utils/prepareFields.ts
+++ b/libs/checkout-separate-address-fields/src/utils/prepareFields.ts
@@ -1,8 +1,11 @@
+import {isOfType} from '@myparcel-dev/ts-utils';
 import {AddressField, PdkUtil, useCheckoutStore, useUtil} from '@myparcel-dev/pdk-checkout-common';
 import {fillSeparateAddressFields} from '../listeners';
 import {ATTRIBUTE_AUTOCOMPLETE, SeparateAddressField} from '../constants';
 import {triggerFormChange} from './triggerFormChange';
 import {setFullStreet} from './setFullStreet';
+import {fillAddressFields} from './fillAddressFields';
+import {splitFullStreet} from './splitFullStreet';
 
 /**
  * Set the correct autocomplete attribute on the street fields if none is present.
@@ -25,8 +28,19 @@ export function prepareFields(): void {
       streetField?.setAttribute(ATTRIBUTE_AUTOCOMPLETE, 'street-address');
     }
 
-    address1Field?.addEventListener('load', fillSeparateAddressFields);
-    address1Field?.addEventListener('animationend', fillSeparateAddressFields);
+    address1Field?.addEventListener('load', (event) => fillSeparateAddressFields(event, addressType));
+    address1Field?.addEventListener('animationend', (event) => fillSeparateAddressFields(event, addressType));
+
+    // When the street field receives a full address (e.g. via browser autofill), split it.
+    streetField.addEventListener('change', (event) => {
+      if (!isOfType<HTMLInputElement>(event.target, 'value')) {
+        return;
+      }
+      const parsed = splitFullStreet(event.target.value);
+      if (parsed[SeparateAddressField.Number]) {
+        fillAddressFields(parsed, addressType);
+      }
+    });
 
     setFullStreet(addressType, false);
   });

--- a/libs/checkout-separate-address-fields/src/utils/prepareFields.ts
+++ b/libs/checkout-separate-address-fields/src/utils/prepareFields.ts
@@ -1,15 +1,11 @@
-import {isOfType} from '@myparcel-dev/ts-utils';
 import {AddressField, PdkUtil, useCheckoutStore, useUtil} from '@myparcel-dev/pdk-checkout-common';
 import {fillSeparateAddressFields} from '../listeners';
-import {ATTRIBUTE_AUTOCOMPLETE, SeparateAddressField} from '../constants';
+import {SeparateAddressField} from '../constants';
 import {triggerFormChange} from './triggerFormChange';
 import {setFullStreet} from './setFullStreet';
 import {fillAddressFields} from './fillAddressFields';
 import {splitFullStreet} from './splitFullStreet';
 
-/**
- * Set the correct autocomplete attribute on the street fields if none is present.
- */
 export function prepareFields(): void {
   const getAddressField = useUtil(PdkUtil.GetAddressField);
 
@@ -24,23 +20,21 @@ export function prepareFields(): void {
 
     const address1Field = getAddressField(AddressField.Address1, addressType);
 
-    if (!streetField?.getAttribute(ATTRIBUTE_AUTOCOMPLETE)) {
-      streetField?.setAttribute(ATTRIBUTE_AUTOCOMPLETE, 'street-address');
-    }
-
     address1Field?.addEventListener('load', (event) => fillSeparateAddressFields(event, addressType));
     address1Field?.addEventListener('animationend', (event) => fillSeparateAddressFields(event, addressType));
 
-    // When the street field receives a full address (e.g. via browser autofill), split it.
-    streetField.addEventListener('change', (event) => {
-      if (!isOfType<HTMLInputElement>(event.target, 'value')) {
-        return;
-      }
-      const parsed = splitFullStreet(event.target.value);
+    // If the street field already contains a full address (e.g. from browser autofill that fired
+    // before this code ran), split it immediately rather than letting the combined value persist.
+    const currentStreet = streetField.value;
+
+    if (currentStreet) {
+      const parsed = splitFullStreet(currentStreet);
+
       if (parsed[SeparateAddressField.Number]) {
         fillAddressFields(parsed, addressType);
+        return;
       }
-    });
+    }
 
     setFullStreet(addressType, false);
   });


### PR DESCRIPTION
INT-1123

## Summary

- Remove `autocomplete="street-address"` from the street name field — this was the root cause, explicitly telling browsers to fill the full address (including house number) into a field meant for the street name only
- Add an init-time check in `prepareFields`: if the street field already holds a full address at initialisation (browser autofill fires before jQuery/blocks init resolves), split it immediately and fill the separate fields
- Dispatch a native `input` event after setting a field value in `setFieldValue`, so React-controlled inputs (WooCommerce Blocks checkout) pick up programmatic value changes
- Pass `addressType` through `fillSeparateAddressFields` to `fillAddressFields`, so the `animationend`/`load` listeners on `address_1` fill the correct address type instead of always defaulting to the store value

## Why

The previous change listener approach fired too late — browser autofill happens before jQuery/blocks initialisation resolves, so the listener never caught the initial autofill. For the WooCommerce Blocks checkout, a separate namespace mismatch (`myparcelnl/` vs `myparcelcom/`, fixed in the WC plugin PR) meant all separate address field JS logic was a no-op anyway.

## Test plan

- [ ] Place an order with a NL shipping address using a browser with a saved address
- [ ] Let the browser autofill the checkout form
- [ ] Verify the street name field shows only the street name; the house number field shows only the number
- [ ] Verify `_shipping_street_name` and `_shipping_house_number` meta are stored correctly (no embedded house number in the street)
- [ ] Test both classic and blocks checkout