### PR TITLE
feat(admin): send business/consumer flag when loading shipment options

### DIFF
--- a/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.spec.ts
+++ b/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.spec.ts
@@ -1,0 +1,56 @@
+import {ref} from 'vue';
+import {describe, expect, it, vi} from 'vitest';
+import {useOrderCapabilitiesQuery} from './useOrderCapabilitiesQuery';
+
+type RequestBody = {recipient: {countryCode: string; isBusiness?: boolean}};
+
+let capturedBody: RequestBody | undefined;
+
+const proxyCapabilities = vi.fn((options: {body: RequestBody}) => {
+  capturedBody = options.body;
+
+  return Promise.resolve({results: []});
+});
+
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: (queryKey: unknown, queryFn: () => Promise<unknown>) => ({queryFn}),
+}));
+
+vi.mock('../../../../sdk', () => ({
+  usePdkAdminApi: () => ({proxyCapabilities}),
+}));
+
+vi.mock('../../../../services', () => ({
+  globalLogger: {error: vi.fn(), debug: vi.fn(), warn: vi.fn(), info: vi.fn()},
+}));
+
+type QueryFnHolder = {queryFn: () => Promise<unknown>};
+
+describe('useOrderCapabilitiesQuery', () => {
+  it('forwards the business flag on the recipient body', async () => {
+    capturedBody = undefined;
+
+    const query = useOrderCapabilitiesQuery(ref({cc: 'NL', isBusiness: true})) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL', isBusiness: true});
+  });
+
+  it('sends an explicit consumer flag on the recipient body', async () => {
+    capturedBody = undefined;
+
+    const query = useOrderCapabilitiesQuery(ref({cc: 'NL', isBusiness: false})) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL', isBusiness: false});
+  });
+
+  it('omits isBusiness when the flag is not provided', async () => {
+    capturedBody = undefined;
+
+    const query = useOrderCapabilitiesQuery(ref({cc: 'NL'})) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL'});
+  });
+});

--- a/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
@@ -19,12 +19,14 @@ export type OrderCapabilitiesInput = {
 };
 
 /**
- * Order-scoped capabilities query — fires the shared CapabilitiesAction with ONLY destination
- * and weight, no carrier/packageType/deliveryType filters. Returns one entry per carrier with
- * the union of `packageTypes`, `deliveryTypes`, and `options` valid for the order context.
+ * Order-scoped capabilities query — fires the shared CapabilitiesAction with ONLY destination,
+ * weight and the recipient business flag, no carrier/packageType/deliveryType filters. Returns
+ * one entry per carrier with the union of `packageTypes`, `deliveryTypes`, and `options` valid
+ * for the order context.
  *
- * Drives the carrier / packageType / deliveryType dropdowns. Refetches only on cc / weight
- * changes so option toggles and dropdown picks don't trigger needless network round-trips.
+ * Drives the carrier / packageType / deliveryType dropdowns. Refetches only on cc / weight /
+ * isBusiness changes so option toggles and dropdown picks don't trigger needless network
+ * round-trips.
  *
  * Errors are logged via `globalLogger.error` so we have a breadcrumb for support, but we
  * deliberately don't surface a user-facing toast — an intermittent capabilities failure

--- a/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useOrderCapabilitiesQuery.ts
@@ -15,6 +15,7 @@ import {usePdkAdminApi} from '../../../../sdk';
 export type OrderCapabilitiesInput = {
   cc?: string;
   weight?: number;
+  isBusiness?: boolean;
 };
 
 /**
@@ -38,7 +39,7 @@ export const useOrderCapabilitiesQuery = (
   return useQuery(
     queryKey,
     async () => {
-      const {cc, weight} = input.value;
+      const {cc, weight, isBusiness} = input.value;
 
       if (!cc) return [];
 
@@ -46,8 +47,8 @@ export const useOrderCapabilitiesQuery = (
       const proxyCapabilities = pdk.proxyCapabilities as unknown as ProxyCapabilitiesCall;
 
       const body: ProxyCapabilitiesBody = {
-        recipient: {countryCode: cc},
-        ...(weight !== undefined ? {physicalProperties: {weight: {value: weight, unit: 'g'}}} : null),
+        recipient: {countryCode: cc, ...(isBusiness === undefined ? null : {isBusiness})},
+        ...(weight === undefined ? null : {physicalProperties: {weight: {value: weight, unit: 'g'}}}),
       };
 
       const response = await proxyCapabilities({body, parameters: {filterSupported: true}});

--- a/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.spec.ts
+++ b/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.spec.ts
@@ -1,0 +1,64 @@
+import {ref} from 'vue';
+import {describe, expect, it, vi} from 'vitest';
+import {useShipmentCapabilitiesQuery} from './useShipmentCapabilitiesQuery';
+
+type RequestBody = {recipient: {countryCode: string; isBusiness?: boolean}};
+
+let capturedBody: RequestBody | undefined;
+
+const proxyCapabilities = vi.fn((options: {body: RequestBody}) => {
+  capturedBody = options.body;
+
+  return Promise.resolve({results: []});
+});
+
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: (queryKey: unknown, queryFn: () => Promise<unknown>) => ({queryFn}),
+}));
+
+vi.mock('../../../../sdk', () => ({
+  usePdkAdminApi: () => ({proxyCapabilities}),
+}));
+
+vi.mock('../../../../services', () => ({
+  globalLogger: {error: vi.fn(), debug: vi.fn(), warn: vi.fn(), info: vi.fn()},
+}));
+
+type QueryFnHolder = {queryFn: () => Promise<unknown>};
+
+const fullSelection = (isBusiness?: boolean) => ({
+  cc: 'NL',
+  carrier: 'POSTNL',
+  packageType: 'PACKAGE',
+  deliveryType: 'STANDARD',
+  ...(isBusiness === undefined ? null : {isBusiness}),
+});
+
+describe('useShipmentCapabilitiesQuery', () => {
+  it('forwards the business flag on the recipient body', async () => {
+    capturedBody = undefined;
+
+    const query = useShipmentCapabilitiesQuery(ref(fullSelection(true))) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL', isBusiness: true});
+  });
+
+  it('sends an explicit consumer flag on the recipient body', async () => {
+    capturedBody = undefined;
+
+    const query = useShipmentCapabilitiesQuery(ref(fullSelection(false))) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL', isBusiness: false});
+  });
+
+  it('omits isBusiness when the flag is not provided', async () => {
+    capturedBody = undefined;
+
+    const query = useShipmentCapabilitiesQuery(ref(fullSelection())) as unknown as QueryFnHolder;
+    await query.queryFn();
+
+    expect(capturedBody?.recipient).toEqual({countryCode: 'NL'});
+  });
+});

--- a/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
@@ -22,6 +22,7 @@ import {usePdkAdminApi} from '../../../../sdk';
 export type CapabilitiesSelection = {
   cc?: string;
   weight?: number;
+  isBusiness?: boolean;
   carrier?: string;
   packageType?: string;
   deliveryType?: string;
@@ -60,7 +61,7 @@ export const useShipmentCapabilitiesQuery = (
   return useQuery(
     queryKey,
     async () => {
-      const {cc, weight, carrier, packageType, deliveryType} = selection.value;
+      const {cc, weight, isBusiness, carrier, packageType, deliveryType} = selection.value;
 
       // The `enabled` gate guarantees these are all present when this runs; TypeScript can't
       // see through the runtime check, so we narrow explicitly here.
@@ -70,10 +71,10 @@ export const useShipmentCapabilitiesQuery = (
       const proxyCapabilities = pdk.proxyCapabilities as unknown as ProxyCapabilitiesCall;
 
       const body: ProxyCapabilitiesBody = {
-        recipient: {countryCode: cc},
+        recipient: {countryCode: cc, ...(isBusiness === undefined ? null : {isBusiness})},
         // PDK orders carry physical-properties weight in grams (see WeightServiceInterface::UNIT_GRAMS),
         // and the SDK's PhysicalPropertiesWeightV2 expects a {value, unit} object — not a primitive.
-        ...(weight !== undefined ? {physicalProperties: {weight: {value: weight, unit: 'g'}}} : null),
+        ...(weight === undefined ? null : {physicalProperties: {weight: {value: weight, unit: 'g'}}}),
         carrier,
         packageType,
         deliveryType,

--- a/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
+++ b/apps/admin/src/actions/composables/queries/account/useShipmentCapabilitiesQuery.ts
@@ -30,10 +30,10 @@ export type CapabilitiesSelection = {
 
 /**
  * Shipment-scoped capabilities query — fires the shared CapabilitiesAction with the FULL
- * selection (carrier + packageType + deliveryType + cc + weight) and returns the matching
- * carrier entry (the one shipment configuration the user has chosen). Drives the option panel
- * and acts as the invalid-combo signal: when `results` is empty, the chosen combination isn't
- * valid for the order context.
+ * selection (carrier + packageType + deliveryType + cc + weight + isBusiness) and returns the
+ * matching carrier entry (the one shipment configuration the user has chosen). Drives the option
+ * panel and acts as the invalid-combo signal: when `results` is empty, the chosen combination
+ * isn't valid for the order context.
  *
  * The selection ref is the only refetch trigger — no window-focus, mount, or reconnect refetches.
  * Server-side option filtering is opted in via the `filterSupported` query parameter so admin sees

--- a/apps/admin/src/forms/shipmentOptions/useCapabilitiesWatcher.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/useCapabilitiesWatcher.spec.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it} from 'vitest';
 import {ref} from 'vue';
+import {describe, expect, it} from 'vitest';
 import {useCapabilitiesWatcher, type FormInput, type OrderInput} from './useCapabilitiesWatcher';
 
 describe('useCapabilitiesWatcher', () => {

--- a/apps/admin/src/forms/shipmentOptions/useCapabilitiesWatcher.ts
+++ b/apps/admin/src/forms/shipmentOptions/useCapabilitiesWatcher.ts
@@ -4,7 +4,8 @@ import {type CapabilitiesSelection} from '../../actions/composables/queries/acco
 
 const DEBOUNCE_MS = 100;
 
-export type OrderInput = {cc?: string; weight?: number};
+export type OrderInput = {cc?: string; weight?: number; isBusiness?: boolean};
+
 export type FormInput = {carrier?: string; packageType?: string; deliveryType?: string};
 
 /**

--- a/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.spec.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it, vi, beforeEach} from 'vitest';
 import {effectScope, nextTick, ref} from 'vue';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
 import {BackendEndpoint, TriState} from '@myparcel-dev/pdk-common';
 import {FIELD_CARRIER, FIELD_DELIVERY_TYPE, FIELD_MANUAL_WEIGHT, FIELD_PACKAGE_TYPE} from './field';
 
@@ -35,12 +35,12 @@ const buildForm = (initial: Record<string, unknown>) => {
   });
 
   return {
-    getValue: <T,>(name: string): T => fields.get(name)?.ref.value as T,
+    getValue: <T>(name: string): T => fields.get(name)?.ref.value as T,
     setExternally: (name: string, value: unknown) => {
       const field = fields.get(name);
 
       if (field) {
-        (field.ref as ReturnType<typeof ref>).value = value;
+        field.ref.value = value;
       } else {
         fields.set(name, {ref: ref(value)});
       }
@@ -55,12 +55,12 @@ beforeEach(() => {
   useShipmentCapabilitiesQueryMock.mockClear();
 });
 
-const orderShape = (cc = 'NL', initialWeight = 1500) =>
+const orderShape = (cc = 'NL', initialWeight = 1500, isBusiness = false) =>
   ({
     externalIdentifier: 'order-1',
-    shippingAddress: {cc},
+    shippingAddress: {cc, isBusiness},
     physicalProperties: {initialWeight},
-  }) as never;
+  } as never);
 
 describe('wireProxyCapabilities', () => {
   it('treats TriState.Inherit (-1) as "no manual override" and falls back to initialWeight', async () => {
@@ -105,10 +105,36 @@ describe('wireProxyCapabilities', () => {
     const orderInputRef = useOrderCapabilitiesQueryMock.mock.calls[0][0] as {value: {weight?: number}};
 
     // Wait for the debounce (refDebounced default 100ms in this codebase).
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 150);
+    });
     await nextTick();
 
     expect(orderInputRef.value.weight).toBe(4200);
+
+    scope.stop();
+  });
+
+  it('forwards the recipient business flag from the order shipping address to both queries', async () => {
+    const form = buildForm({
+      [FIELD_CARRIER]: 'POSTNL',
+      [FIELD_PACKAGE_TYPE]: 'PACKAGE',
+      [FIELD_DELIVERY_TYPE]: 'STANDARD',
+      [FIELD_MANUAL_WEIGHT]: TriState.Inherit,
+    });
+
+    const scope = effectScope();
+    const {wireProxyCapabilities} = await import('./wireProxyCapabilities');
+
+    scope.run(() => {
+      wireProxyCapabilities(form as never, orderShape('NL', 1500, true));
+    });
+
+    const orderInputRef = useOrderCapabilitiesQueryMock.mock.calls[0][0] as {value: {isBusiness?: boolean}};
+    const selectionRef = useShipmentCapabilitiesQueryMock.mock.calls[0][0] as {value: {isBusiness?: boolean}};
+
+    expect(orderInputRef.value.isBusiness).toBe(true);
+    expect(selectionRef.value.isBusiness).toBe(true);
 
     scope.stop();
   });

--- a/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.spec.ts
@@ -55,10 +55,12 @@ beforeEach(() => {
   useShipmentCapabilitiesQueryMock.mockClear();
 });
 
-const orderShape = (cc = 'NL', initialWeight = 1500, isBusiness = false) =>
+// `isBusiness` is omitted from the shipping address unless explicitly passed — production
+// orders may not carry the flag at all, so the flag-absent shape is the representative default.
+const orderShape = (cc = 'NL', initialWeight = 1500, isBusiness: boolean | undefined = undefined) =>
   ({
     externalIdentifier: 'order-1',
-    shippingAddress: {cc, isBusiness},
+    shippingAddress: {cc, ...(isBusiness === undefined ? null : {isBusiness})},
     physicalProperties: {initialWeight},
   } as never);
 
@@ -135,6 +137,30 @@ describe('wireProxyCapabilities', () => {
 
     expect(orderInputRef.value.isBusiness).toBe(true);
     expect(selectionRef.value.isBusiness).toBe(true);
+
+    scope.stop();
+  });
+
+  it('leaves isBusiness undefined for both queries when the order has no flag', async () => {
+    const form = buildForm({
+      [FIELD_CARRIER]: 'POSTNL',
+      [FIELD_PACKAGE_TYPE]: 'PACKAGE',
+      [FIELD_DELIVERY_TYPE]: 'STANDARD',
+      [FIELD_MANUAL_WEIGHT]: TriState.Inherit,
+    });
+
+    const scope = effectScope();
+    const {wireProxyCapabilities} = await import('./wireProxyCapabilities');
+
+    scope.run(() => {
+      wireProxyCapabilities(form as never, orderShape());
+    });
+
+    const orderInputRef = useOrderCapabilitiesQueryMock.mock.calls[0][0] as {value: {isBusiness?: boolean}};
+    const selectionRef = useShipmentCapabilitiesQueryMock.mock.calls[0][0] as {value: {isBusiness?: boolean}};
+
+    expect(orderInputRef.value.isBusiness).toBeUndefined();
+    expect(selectionRef.value.isBusiness).toBeUndefined();
 
     scope.stop();
   });

--- a/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
+++ b/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
@@ -37,15 +37,16 @@ const resolveOrderInput = (form: FormInstance, order: Plugin.ModelContextOrderDa
 };
 
 /**
- * Wire BOTH capabilities queries — order-scoped (cc + weight) and shipment-scoped (full
- * selection) — into the shipment-options form for a single order, register them in the query
- * store under composite-string modifiers (`${orderId}.order` and `${orderId}.shipment`), and
- * tear them down when the form's scope disposes (modal close).
+ * Wire BOTH capabilities queries — order-scoped (cc + weight + isBusiness) and shipment-scoped
+ * (full selection) — into the shipment-options form for a single order, register them in the
+ * query store under composite-string modifiers (`${orderId}.order` and `${orderId}.shipment`),
+ * and tear them down when the form's scope disposes (modal close).
  *
  * The two queries serve different concerns:
  *
  * - **Order query** drives the carrier / packageType / deliveryType dropdowns from each
- *   carrier's flat union arrays. Refetches only when destination or weight change.
+ *   carrier's flat union arrays. Refetches only when destination, weight or the recipient
+ *   business flag change.
  * - **Shipment query** drives per-option metadata (`isRequired`, `requires`, `excludes`,
  *   `insuredAmount`) for the chosen combination. Refetches when any axis of the selection
  *   changes; the empty-result case is the invalid-combo signal consumed by

--- a/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
+++ b/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
@@ -1,8 +1,8 @@
 import {computed, onScopeDispose, type Ref} from 'vue';
 import {type FormInstance} from '@myparcel-dev/vue-form-builder';
 import {BackendEndpoint, type Plugin} from '@myparcel-dev/pdk-common';
-import {globalLogger} from '../../services';
 import {useQueryStore} from '../../stores';
+import {globalLogger} from '../../services';
 import {
   useShipmentCapabilitiesQuery,
   type CapabilitiesSelection,
@@ -13,6 +13,28 @@ import {
 } from '../../actions/composables/queries/account/useOrderCapabilitiesQuery';
 import {useCapabilitiesWatcher, type FormInput, type OrderInput} from './useCapabilitiesWatcher';
 import {FIELD_CARRIER, FIELD_DELIVERY_TYPE, FIELD_MANUAL_WEIGHT, FIELD_PACKAGE_TYPE} from './field';
+
+/**
+ * Resolve the order-scoped capabilities input from the form + order.
+ *
+ * Read weight through `form.getValue()` (which goes through `q(field.ref)` / `toValue`) rather
+ * than `form.values` so reactive deps are tracked when called inside a computed. Manual weight from
+ * `FIELD_MANUAL_WEIGHT` wins when set — it carries `TriState.Inherit` (-1) when unset, and only a
+ * positive number is a real override; otherwise fall back to the order's initial weight.
+ *
+ * `isBusiness` is the PDK-derived recipient flag (from the company name), forwarded as-is — no
+ * company or other PII is handled here.
+ */
+const resolveOrderInput = (form: FormInstance, order: Plugin.ModelContextOrderDataContext): OrderInput => {
+  const manualWeightRaw = form.getValue(FIELD_MANUAL_WEIGHT);
+  const manualWeight = typeof manualWeightRaw === 'number' && manualWeightRaw > 0 ? manualWeightRaw : undefined;
+
+  return {
+    cc: order.shippingAddress?.cc,
+    weight: manualWeight ?? order.physicalProperties?.initialWeight,
+    isBusiness: order.shippingAddress?.isBusiness,
+  };
+};
 
 /**
  * Wire BOTH capabilities queries — order-scoped (cc + weight) and shipment-scoped (full
@@ -51,20 +73,7 @@ export const wireProxyCapabilities = (
   const orderModifier = `${orderId}.order`;
   const shipmentModifier = `${orderId}.shipment`;
 
-  // Use `form.getValue(name)` (which goes through `q(field.ref)` / `toValue` internally) rather
-  // than `form.values[name]` so reactive deps are tracked correctly inside computed/watchers.
-  const orderInput = computed<OrderInput>(() => {
-    // FIELD_MANUAL_WEIGHT carries `TriState.Inherit` (-1) when the user hasn't entered a manual
-    // override; only positive numbers represent an actual weight. Treat anything else as "unset"
-    // and fall back to the order's initial weight.
-    const manualWeightRaw = form.getValue(FIELD_MANUAL_WEIGHT);
-    const manualWeight = typeof manualWeightRaw === 'number' && manualWeightRaw > 0 ? manualWeightRaw : undefined;
-
-    return {
-      cc: order.shippingAddress?.cc,
-      weight: manualWeight ?? order.physicalProperties?.initialWeight,
-    };
-  });
+  const orderInput = computed<OrderInput>(() => resolveOrderInput(form, order));
 
   const formInput = computed<FormInput>(() => ({
     carrier: form.getValue<string | undefined>(FIELD_CARRIER),
@@ -77,6 +86,7 @@ export const wireProxyCapabilities = (
   const orderInputForQuery = computed<OrderCapabilitiesInput>(() => ({
     cc: selection.value.cc,
     weight: selection.value.weight,
+    isBusiness: selection.value.isBusiness,
   }));
 
   const orderQuery = useOrderCapabilitiesQuery(orderInputForQuery);

--- a/apps/admin/src/types/sdk.types.ts
+++ b/apps/admin/src/types/sdk.types.ts
@@ -209,7 +209,7 @@ interface ProxyCapabilitiesDefinition extends PdkEndpointDefinition {
    * SDK's `PhysicalPropertiesWeightV2` model defines it on the wire.
    */
   body: {
-    recipient: {countryCode: string};
+    recipient: {countryCode: string; isBusiness?: boolean};
     physicalProperties?: {
       weight?: {value: number; unit: 'g' | 'kg'};
     };

--- a/libs/common/src/types/php-pdk.types.ts
+++ b/libs/common/src/types/php-pdk.types.ts
@@ -80,6 +80,7 @@ export namespace Base {
     boxNumber?: string;
     cc?: string;
     city?: string;
+    isBusiness?: boolean;
     postalCode?: string;
     region?: string;
     state?: string;


### PR DESCRIPTION
the admin now tells the capabilities request whether an order is for a business or a consumer, so it gets back the right options.

It reads a true/false flag (isBusiness) that the PDK works out from the recipient's company name, and passes it along on both capabilities requests. Only that flag travels — never the company name or other personal data — and it's left off when it isn't set. This is the admin side of the PDK change in https://github.com/myparcelnl/pdk/pull/504.

Fixes INT-1690
Depends on https://github.com/myparcelnl/pdk/pull/504

🤖 Generated with [Claude Code](https://claude.com/claude-code)
