### PR TITLE
fix(admin): enforce carrier rules on shipment options in settings and orders

### DIFF
--- a/apps/admin/src/data/components.ts
+++ b/apps/admin/src/data/components.ts
@@ -229,6 +229,14 @@ export enum AdminComponent {
   MultiDateInput = 'MultiDateInput',
 }
 
+/**
+ * Components whose v-model must carry tri-state ints in form state. Their
+ * rendered instances are wrapped with the tri-state adapter when resolved as
+ * form components, so boolean emits from plugin implementations are converted
+ * at the component boundary.
+ */
+export const triStateModelComponentNames = [AdminComponent.ToggleInput, AdminComponent.TriStateInput] as const;
+
 export const requiredAdminComponentNames = [
   AdminComponent.Box,
   AdminComponent.Button,

--- a/apps/admin/src/data/components.ts
+++ b/apps/admin/src/data/components.ts
@@ -237,6 +237,13 @@ export enum AdminComponent {
  */
 export const triStateModelComponentNames = [AdminComponent.ToggleInput, AdminComponent.TriStateInput] as const;
 
+/**
+ * Of the components above, the ones that model their value as a boolean: plain toggles, which
+ * are checkboxes in the plugins. They get a boolean for their modelValue while the form keeps
+ * tri-state ints. TriStateInput is absent on purpose — it handles the ints itself.
+ */
+export const booleanModelComponentNames = [AdminComponent.ToggleInput] as const;
+
 export const requiredAdminComponentNames = [
   AdminComponent.Box,
   AdminComponent.Button,

--- a/apps/admin/src/forms/helpers/index.ts
+++ b/apps/admin/src/forms/helpers/index.ts
@@ -12,3 +12,4 @@ export * from './setFieldProp';
 export * from './triStateFieldIsEnabled';
 export * from './updateFieldsDefaults';
 export * from './useFormCapabilities';
+export * from './withTriStateModel';

--- a/apps/admin/src/forms/helpers/resolveFormComponent.ts
+++ b/apps/admin/src/forms/helpers/resolveFormComponent.ts
@@ -1,10 +1,19 @@
 import {type Component, resolveComponent} from 'vue';
 import {memoize} from 'lodash-unified';
 import {prefixComponent} from '../../utils';
-import {type AdminComponent} from '../../data';
+import {type AdminComponent, triStateModelComponentNames} from '../../data';
+import {withTriStateModel} from './withTriStateModel';
 
 const memoizedResolveFormComponent = memoize((componentName: AdminComponent): Component => {
-  return resolveComponent(prefixComponent(componentName)) as Component;
+  const component = resolveComponent(prefixComponent(componentName)) as Component;
+
+  // Toggle-like components must expose tri-state ints to the form, regardless
+  // of how the registered plugin component models its value internally.
+  if ((triStateModelComponentNames as readonly AdminComponent[]).includes(componentName)) {
+    return withTriStateModel(component);
+  }
+
+  return component;
 });
 
 export const resolveFormComponent = (componentName: AdminComponent): Component => {

--- a/apps/admin/src/forms/helpers/resolveFormComponent.ts
+++ b/apps/admin/src/forms/helpers/resolveFormComponent.ts
@@ -1,7 +1,7 @@
 import {type Component, resolveComponent} from 'vue';
 import {memoize} from 'lodash-unified';
 import {prefixComponent} from '../../utils';
-import {type AdminComponent, triStateModelComponentNames} from '../../data';
+import {type AdminComponent, booleanModelComponentNames, triStateModelComponentNames} from '../../data';
 import {withTriStateModel} from './withTriStateModel';
 
 const memoizedResolveFormComponent = memoize((componentName: AdminComponent): Component => {
@@ -10,7 +10,10 @@ const memoizedResolveFormComponent = memoize((componentName: AdminComponent): Co
   // Toggle-like components must expose tri-state ints to the form, regardless
   // of how the registered plugin component models its value internally.
   if ((triStateModelComponentNames as readonly AdminComponent[]).includes(componentName)) {
-    return withTriStateModel(component);
+    return withTriStateModel(
+      component,
+      (booleanModelComponentNames as readonly AdminComponent[]).includes(componentName),
+    );
   }
 
   return component;

--- a/apps/admin/src/forms/helpers/triStateFieldIsEnabled.ts
+++ b/apps/admin/src/forms/helpers/triStateFieldIsEnabled.ts
@@ -1,8 +1,31 @@
 import {toValue} from 'vue';
-import {TriState} from '@myparcel-dev/pdk-common';
 import {type FormInstance} from '@myparcel-dev/vue-form-builder';
+import {TriState} from '@myparcel-dev/pdk-common';
 import {type ElementInstance, type TriStateInputProps} from '../../types';
 
+/**
+ * Whether a tri-state value counts as enabled: explicitly on, or inheriting while the
+ * inherited default is on. The single definition of this rule — use it instead of comparing
+ * tri-state values inline.
+ *
+ * @param value - The raw tri-state value.
+ * @param defaultValue - The inherited default shown when the value is `Inherit`.
+ */
+export const triStateValueIsEnabled = (value: TriState | undefined, defaultValue: TriState | undefined): boolean => {
+  if (TriState.Inherit === value) {
+    return TriState.On === defaultValue;
+  }
+
+  return TriState.On === value;
+};
+
+/**
+ * Whether a tri-state form field is effectively enabled, reading its value and inherited
+ * default (`props.defaultValue`, maintained by `updateFieldsDefaults`) from the form.
+ *
+ * @param form - The form holding the field.
+ * @param fieldName - The full field name, e.g. `deliveryOptions.shipmentOptions.requiresSignature`.
+ */
 export const triStateFieldIsEnabled = (form: FormInstance, fieldName: string): boolean => {
   const field = form.getField(fieldName) as unknown as ElementInstance<TriState, TriStateInputProps> | undefined;
 
@@ -10,11 +33,5 @@ export const triStateFieldIsEnabled = (form: FormInstance, fieldName: string): b
     return false;
   }
 
-  const value = toValue(field.ref);
-
-  if (TriState.Inherit === value) {
-    return TriState.On === field.props.defaultValue;
-  }
-
-  return TriState.On === value;
+  return triStateValueIsEnabled(toValue(field.ref), field.props.defaultValue);
 };

--- a/apps/admin/src/forms/helpers/useFormCapabilities.spec.ts
+++ b/apps/admin/src/forms/helpers/useFormCapabilities.spec.ts
@@ -1,5 +1,5 @@
-import {describe, expect, it, vi, beforeEach} from 'vitest';
 import {ref} from 'vue';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
 import {AdminContextKey, BackendEndpoint, type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
 
 type FakeQuery = {
@@ -25,8 +25,7 @@ const buildQueryStore = () => {
     setDynamicCarriers: (carriers: CarrierModel[]) => {
       dynamicCarriers.value = carriers;
     },
-    has: (endpoint: BackendEndpoint, modifier: string) =>
-      queries.has(`${endpoint}.${modifier}`),
+    has: (endpoint: BackendEndpoint, modifier: string) => queries.has(`${endpoint}.${modifier}`),
     get: (endpoint: BackendEndpoint, modifier?: string) => {
       if (endpoint === BackendEndpoint.FetchContext && modifier === AdminContextKey.Dynamic) {
         return {
@@ -63,11 +62,12 @@ const buildCarrier = (overrides: Partial<CarrierModel>): CarrierModel =>
     deliveryTypes: [],
     options: {},
     ...overrides,
-  }) as CarrierModel;
+  } as CarrierModel);
 
-const formStub = (carrierName: string) => ({
-  getValue: (name: string) => (name === 'deliveryOptions.carrier' ? carrierName : undefined),
-}) as never;
+const formStub = (carrierName: string) =>
+  ({
+    getValue: (name: string) => (name === 'deliveryOptions.carrier' ? carrierName : undefined),
+  } as never);
 
 describe('useFormCapabilities', () => {
   beforeEach(() => {
@@ -148,29 +148,6 @@ describe('useFormCapabilities', () => {
       const {useFormCapabilities} = await import('./useFormCapabilities');
 
       expect(useFormCapabilities().getCarrierCapabilitiesForShipment(formStub('POSTNL'))).toBeUndefined();
-    });
-  });
-
-  describe('hasShipmentOption', () => {
-    it('returns true when the shipment carrier exposes the option', async () => {
-      const shipment = buildCarrier({
-        carrier: 'POSTNL',
-        options: {requiresSignature: {} as never},
-      });
-      queryStore.setQuery(shipmentModifier('order-1'), 'success', [shipment]);
-
-      const {useFormCapabilities} = await import('./useFormCapabilities');
-
-      expect(useFormCapabilities().hasShipmentOption(formStub('POSTNL'), 'requiresSignature')).toBe(true);
-    });
-
-    it('returns false when the option is absent from the carrier', async () => {
-      const shipment = buildCarrier({carrier: 'POSTNL', options: {}});
-      queryStore.setQuery(shipmentModifier('order-1'), 'success', [shipment]);
-
-      const {useFormCapabilities} = await import('./useFormCapabilities');
-
-      expect(useFormCapabilities().hasShipmentOption(formStub('POSTNL'), 'requiresSignature')).toBe(false);
     });
   });
 

--- a/apps/admin/src/forms/helpers/useFormCapabilities.ts
+++ b/apps/admin/src/forms/helpers/useFormCapabilities.ts
@@ -4,7 +4,7 @@ import {AdminContextKey, BackendEndpoint, type CarrierModel, TriState} from '@my
 import {FIELD_CARRIER} from '../shipmentOptions/field';
 import {getOrderId} from '../../utils';
 import {type AdminContext, type SelectOption} from '../../types';
-import {useQueryStore, type ResolvedQuery} from '../../stores';
+import {useQueryStore} from '../../stores';
 import {Format, type Formatter} from '../../composables';
 
 interface InsuranceAmountData {
@@ -46,13 +46,6 @@ export type FormCapabilities = {
   getCarrierCapabilitiesForShipment: (form: FormInstance) => CarrierModel | undefined;
 
   /**
-   * Whether the chosen shipment configuration supports a given option. Reads from the
-   * shipment-scoped carrier; falls through to order-level data when shipment data isn't
-   * available yet.
-   */
-  hasShipmentOption: (form: FormInstance, option: string) => boolean;
-
-  /**
    * Insurance amount bracket options derived from the currently selected carrier's
    * `insuredAmount` data. Amounts in the context are in cents; emitted values are strings
    * representing cent amounts so they round-trip through form select inputs unchanged.
@@ -82,9 +75,7 @@ export type FormCapabilities = {
  */
 export const useFormCapabilities = (): FormCapabilities => {
   const queryStore = useQueryStore();
-  const dynamicContextQuery = queryStore.get(BackendEndpoint.FetchContext, AdminContextKey.Dynamic) as ResolvedQuery<
-    BackendEndpoint.FetchContext
-  >;
+  const dynamicContextQuery = queryStore.get(BackendEndpoint.FetchContext, AdminContextKey.Dynamic);
   const orderId = getOrderId();
 
   const orderModifier = typeof orderId === 'string' ? `${orderId}.order` : undefined;
@@ -97,7 +88,7 @@ export const useFormCapabilities = (): FormCapabilities => {
 
     if (toValue(query.status) !== 'success') return undefined;
 
-    return (toValue(query.data) ?? []) as CarrierModel[];
+    return toValue(query.data) ?? [];
   };
 
   const liveDynamicCarriers = (): CarrierModel[] => {
@@ -129,12 +120,6 @@ export const useFormCapabilities = (): FormCapabilities => {
     const chosenCarrier = form.getValue(FIELD_CARRIER);
 
     return carriers.find((carrier) => carrier.carrier === chosenCarrier);
-  };
-
-  const hasShipmentOption = (form: FormInstance, option: string): boolean => {
-    const carrier = getCarrierCapabilitiesForShipment(form);
-
-    return Object.hasOwn(carrier?.options ?? {}, option);
   };
 
   const getInsuranceOptions = (form: FormInstance, formatter: Formatter): SelectOption[] => {
@@ -170,7 +155,6 @@ export const useFormCapabilities = (): FormCapabilities => {
   return {
     getCarrierCapabilitiesForOrder,
     getCarrierCapabilitiesForShipment,
-    hasShipmentOption,
     getInsuranceOptions,
   };
 };

--- a/apps/admin/src/forms/helpers/withTriStateModel.spec.ts
+++ b/apps/admin/src/forms/helpers/withTriStateModel.spec.ts
@@ -66,14 +66,6 @@ describe('withTriStateModel', () => {
     expect(wrapper.find('input').element.checked).toBe(true);
   });
 
-  it('emits exactly once per inner emit', async () => {
-    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.Off}});
-
-    await wrapper.find('input').setValue(true);
-
-    expect(wrapper.emitted('update:modelValue')).toHaveLength(1);
-  });
-
   it('forwards attributes and slots to the inner component', () => {
     const wrapper = mount(withTriStateModel(BooleanToggleStub), {
       props: {modelValue: TriState.Off},

--- a/apps/admin/src/forms/helpers/withTriStateModel.spec.ts
+++ b/apps/admin/src/forms/helpers/withTriStateModel.spec.ts
@@ -1,0 +1,157 @@
+import {defineComponent, h, ref} from 'vue';
+import {afterEach, describe, expect, it} from 'vitest';
+import {flushPromises, mount} from '@vue/test-utils';
+import {defineForm, MagicForm, useFormBuilder} from '@myparcel-dev/vue-form-builder';
+import {TriState} from '@myparcel-dev/pdk-common';
+import {buildAfterUpdate} from '../form-builder';
+import {withTriStateModel} from './withTriStateModel';
+
+/**
+ * Stand-in for a plugin toggle component: a native checkbox with a boolean
+ * v-model, like the WooCommerce and PrestaShop toggle inputs. Emits booleans,
+ * not tri-state ints.
+ */
+const BooleanToggleStub = defineComponent({
+  name: 'BooleanToggleStub',
+  props: {
+    // eslint-disable-next-line vue/require-prop-types
+    modelValue: {type: null, default: undefined},
+  },
+  emits: ['update:modelValue'],
+  setup(props, {emit, slots}) {
+    return () =>
+      h('label', [
+        h('input', {
+          type: 'checkbox',
+          checked: Boolean(props.modelValue),
+          onChange: (event: Event) => emit('update:modelValue', (event.target as HTMLInputElement).checked),
+        }),
+        slots.default?.(),
+      ]);
+  },
+});
+
+describe('withTriStateModel', () => {
+  it('converts a boolean true emit to tri-state on', async () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.Off}});
+
+    await wrapper.find('input').setValue(true);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[TriState.On]]);
+  });
+
+  it('converts a boolean false emit to tri-state off', () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.On}});
+
+    wrapper.findComponent(BooleanToggleStub).vm.$emit('update:modelValue', false);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[TriState.Off]]);
+  });
+
+  it('passes tri-state int emits through unchanged', () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.Off}});
+    const inner = wrapper.findComponent(BooleanToggleStub);
+
+    inner.vm.$emit('update:modelValue', TriState.Inherit);
+    inner.vm.$emit('update:modelValue', TriState.On);
+    inner.vm.$emit('update:modelValue', TriState.Off);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[TriState.Inherit], [TriState.On], [TriState.Off]]);
+  });
+
+  it('forwards modelValue to the inner component unchanged', () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.On}});
+
+    expect(wrapper.findComponent(BooleanToggleStub).props('modelValue')).toBe(TriState.On);
+    expect(wrapper.find('input').element.checked).toBe(true);
+  });
+
+  it('emits exactly once per inner emit', async () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {props: {modelValue: TriState.Off}});
+
+    await wrapper.find('input').setValue(true);
+
+    expect(wrapper.emitted('update:modelValue')).toHaveLength(1);
+  });
+
+  it('forwards attributes and slots to the inner component', () => {
+    const wrapper = mount(withTriStateModel(BooleanToggleStub), {
+      props: {modelValue: TriState.Off},
+      attrs: {'data-test-id': 'my-toggle'},
+      slots: {default: () => 'toggle label'},
+    });
+    const inner = wrapper.findComponent(BooleanToggleStub);
+
+    expect(inner.attributes('data-test-id')).toBe('my-toggle');
+    expect(inner.text()).toBe('toggle label');
+  });
+});
+
+describe('withTriStateModel in a form', () => {
+  afterEach(() => {
+    useFormBuilder().forms.value = {};
+  });
+
+  it('makes strict $eq afterUpdate rules fire on toggle interaction', async () => {
+    expect.assertions(2);
+
+    const form = defineForm('test', {
+      fields: [
+        {
+          name: 'exportAgeCheck',
+          component: withTriStateModel(BooleanToggleStub),
+          ref: ref(TriState.Off),
+          afterUpdate: buildAfterUpdate(
+            [{$setValue: {$value: TriState.On, $target: 'exportSignature', $if: [{$eq: TriState.On}]}}],
+            '',
+          ),
+        },
+        {
+          name: 'exportSignature',
+          component: 'input',
+          ref: ref(TriState.Off),
+        },
+      ],
+    });
+
+    const wrapper = mount(MagicForm, {props: {form}});
+    await flushPromises();
+
+    await wrapper.find('input[type=checkbox]').setValue(true);
+    await flushPromises();
+
+    expect(form.values.exportAgeCheck).toBe(TriState.On);
+    expect(form.values.exportSignature).toBe(TriState.On);
+  });
+
+  it('does not fire negated conditions spuriously while toggling on', async () => {
+    expect.assertions(1);
+
+    const form = defineForm('test', {
+      fields: [
+        {
+          name: 'exportAgeCheck',
+          component: withTriStateModel(BooleanToggleStub),
+          ref: ref(TriState.Off),
+          afterUpdate: buildAfterUpdate(
+            [{$setValue: {$value: TriState.On, $target: 'exportSignature', $if: [{$ne: TriState.On}]}}],
+            '',
+          ),
+        },
+        {
+          name: 'exportSignature',
+          component: 'input',
+          ref: ref(TriState.Off),
+        },
+      ],
+    });
+
+    const wrapper = mount(MagicForm, {props: {form}});
+    await flushPromises();
+
+    await wrapper.find('input[type=checkbox]').setValue(true);
+    await flushPromises();
+
+    expect(form.values.exportSignature).toBe(TriState.Off);
+  });
+});

--- a/apps/admin/src/forms/helpers/withTriStateModel.ts
+++ b/apps/admin/src/forms/helpers/withTriStateModel.ts
@@ -1,0 +1,35 @@
+import {type Component, defineComponent, h} from 'vue';
+import {type AnyVal} from '../form-builder/types';
+import {booleanToTriState} from '../../utils';
+
+/**
+ * Wraps a form component so its v-model always carries tri-state ints in form
+ * state. Plugin toggle components are native checkboxes that emit booleans;
+ * this adapter converts those emits at the component boundary, so strict $eq
+ * conditions, afterUpdate operations, submitted values and stored settings all
+ * see the same canonical tri-state representation. Int emits (including
+ * Inherit) pass through untouched; the value passed down is never converted.
+ */
+export const withTriStateModel = (component: Component | string): Component =>
+  defineComponent({
+    name: 'WithTriStateModel',
+    inheritAttrs: false,
+    props: {
+      // eslint-disable-next-line vue/require-prop-types
+      modelValue: {type: null, default: undefined},
+    },
+    emits: ['update:modelValue'],
+    setup(props, {attrs, emit, slots}) {
+      return () =>
+        h(
+          component as Component,
+          {
+            ...attrs,
+            modelValue: props.modelValue,
+            'onUpdate:modelValue': (value: AnyVal) =>
+              emit('update:modelValue', typeof value === 'boolean' ? booleanToTriState(value) : value),
+          },
+          slots,
+        );
+    },
+  });

--- a/apps/admin/src/forms/helpers/withTriStateModel.ts
+++ b/apps/admin/src/forms/helpers/withTriStateModel.ts
@@ -3,12 +3,16 @@ import {type AnyVal} from '../form-builder/types';
 import {booleanToTriState} from '../../utils';
 
 /**
- * Wraps a form component so its v-model always carries tri-state ints in form
- * state. Plugin toggle components are native checkboxes that emit booleans;
- * this adapter converts those emits at the component boundary, so strict $eq
- * conditions, afterUpdate operations, submitted values and stored settings all
- * see the same canonical tri-state representation. Int emits (including
- * Inherit) pass through untouched; the value passed down is never converted.
+ * Wraps a form component so its v-model always carries tri-state ints (1/0/-1)
+ * in form state. Plugin toggle components are native checkboxes that emit
+ * booleans; this wrapper converts those emits right where the component hands
+ * its value to the form, so strict $eq conditions, afterUpdate operations,
+ * submitted values and stored settings all see the same tri-state ints. Int
+ * emits (including Inherit) pass through untouched; the value passed down into
+ * the component is never converted.
+ *
+ * @param component - The component to wrap: the resolved (registered) plugin component, or a
+ *   component name string when resolution happens at render time.
  */
 export const withTriStateModel = (component: Component | string): Component =>
   defineComponent({

--- a/apps/admin/src/forms/helpers/withTriStateModel.ts
+++ b/apps/admin/src/forms/helpers/withTriStateModel.ts
@@ -1,6 +1,7 @@
 import {type Component, defineComponent, h} from 'vue';
+import {type TriState} from '@myparcel-dev/pdk-common';
 import {type AnyVal} from '../form-builder/types';
-import {booleanToTriState} from '../../utils';
+import {booleanToTriState, triStateToBoolean} from '../../utils';
 
 /**
  * Wraps a form component so its v-model always carries tri-state ints (1/0/-1)
@@ -8,13 +9,15 @@ import {booleanToTriState} from '../../utils';
  * booleans; this wrapper converts those emits right where the component hands
  * its value to the form, so strict $eq conditions, afterUpdate operations,
  * submitted values and stored settings all see the same tri-state ints. Int
- * emits (including Inherit) pass through untouched; the value passed down into
- * the component is never converted.
+ * emits (including Inherit) pass through untouched.
  *
  * @param component - The component to wrap: the resolved (registered) plugin component, or a
  *   component name string when resolution happens at render time.
+ * @param booleanModel - Whether the wrapped component models its value as a boolean (a plain
+ *   toggle). Those get a boolean handed back down, so a checkbox never receives an int for its
+ *   `modelValue`. Components that understand tri-state themselves receive the int unchanged.
  */
-export const withTriStateModel = (component: Component | string): Component =>
+export const withTriStateModel = (component: Component | string, booleanModel = false): Component =>
   defineComponent({
     name: 'WithTriStateModel',
     inheritAttrs: false,
@@ -29,7 +32,10 @@ export const withTriStateModel = (component: Component | string): Component =>
           component as Component,
           {
             ...attrs,
-            modelValue: props.modelValue,
+            modelValue:
+              booleanModel && typeof props.modelValue === 'number'
+                ? triStateToBoolean(props.modelValue as TriState)
+                : props.modelValue,
             'onUpdate:modelValue': (value: AnyVal) =>
               emit('update:modelValue', typeof value === 'boolean' ? booleanToTriState(value) : value),
           },

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.spec.ts
@@ -48,6 +48,10 @@ vi.mock('./fieldFactoryRegistry', () => ({
   fieldFactoryRegistry: {},
 }));
 
+vi.mock('./useShipmentOptionsState', () => ({
+  useShipmentOptionsState: vi.fn(),
+}));
+
 const mockedUseContext = vi.mocked(useContext);
 
 const dynamicOptionKeys = (form: unknown): string[] => {

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
@@ -11,8 +11,9 @@ import {createShipmentFormName} from '../../utils';
 import {useModalStore} from '../../stores';
 import {AdminModalKey} from '../../data';
 import {useAdminConfig, useContext} from '../../composables';
-import {useCapabilitiesAutoClear} from './useCapabilitiesAutoClear';
 import {wireProxyCapabilities} from './wireProxyCapabilities';
+import {useShipmentOptionsState} from './useShipmentOptionsState';
+import {useCapabilitiesAutoClear} from './useCapabilitiesAutoClear';
 import {type ShipmentOptionsRefs} from './types';
 import {createShipmentOptionField} from './fields/createShipmentOptionField';
 import {createDeliveryTypeField} from './fields/createDeliveryTypeField';
@@ -61,21 +62,42 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
     fields: createShipmentOptionsFields(refs, order, allOptionKeys),
   });
 
-  if (!isBulk && order.externalIdentifier) {
-    const wired = wireProxyCapabilities(form, order);
-
-    if (wired) {
-      useCapabilitiesAutoClear(
-        form,
-        allOptionKeys,
-        order.externalIdentifier,
-        order.inheritedDeliveryOptions,
-        wired.selection,
-      );
-    }
-  }
+  wireCapabilitiesBehavior(form, order, allOptionKeys, isBulk);
 
   return form;
+};
+
+/**
+ * Connect the capability-driven behavior to the form. The option-state module is connected
+ * for every form: without the per-order capability queries (bulk forms, orders without an
+ * identifier) it still resolves which options are available per carrier, it just never locks
+ * or forces anything.
+ *
+ * @param form - The freshly defined shipment-options form.
+ * @param order - The order being edited; an empty object when editing multiple orders at once.
+ * @param allOptionKeys - Every capability option key a field was created for (union across
+ *   all carriers in the dynamic context).
+ * @param isBulk - Whether the form edits multiple orders at once; bulk forms get no per-order
+ *   capability queries.
+ */
+const wireCapabilitiesBehavior = (
+  form: FormInstance,
+  order: Plugin.ModelContextOrderDataContext,
+  allOptionKeys: string[],
+  isBulk: boolean,
+): void => {
+  const orderId = order.externalIdentifier;
+  const proxyQueries = !isBulk && orderId ? wireProxyCapabilities(form, order) : undefined;
+
+  useShipmentOptionsState(
+    form,
+    allOptionKeys,
+    proxyQueries && orderId ? {orderId, selection: proxyQueries.selection} : undefined,
+  );
+
+  if (proxyQueries && orderId) {
+    useCapabilitiesAutoClear(form, allOptionKeys, orderId, order.inheritedDeliveryOptions, proxyQueries.selection);
+  }
 };
 
 /**
@@ -110,10 +132,7 @@ const collectAllOptionKeys = (carriers: {options?: Record<string, unknown> | nul
  * Instead of a hardcoded ALL_FIELDS list, refs are built from the union of
  * all carrier options in the dynamic context.
  */
-const buildDynamicRefs = (
-  order: Plugin.ModelContextOrderDataContext,
-  optionKeys: string[],
-): ShipmentOptionsRefs => {
+const buildDynamicRefs = (order: Plugin.ModelContextOrderDataContext, optionKeys: string[]): ShipmentOptionsRefs => {
   const refs: ShipmentOptionsRefs = {};
 
   // Static field refs

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
@@ -33,8 +33,8 @@ import {
   FIELD_LENGTH,
   FIELD_MANUAL_WEIGHT,
   FIELD_PACKAGE_TYPE,
-  FIELD_SHIPMENT_OPTIONS_PREFIX,
   FIELD_WIDTH,
+  optionFieldName,
 } from './field';
 
 export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrder>): FormInstance => {
@@ -88,15 +88,18 @@ const wireCapabilitiesBehavior = (
 ): void => {
   const orderId = order.externalIdentifier;
   const proxyQueries = !isBulk && orderId ? wireProxyCapabilities(form, order) : undefined;
+  const shipmentQuery = proxyQueries && orderId ? {orderId, selection: proxyQueries.selection} : undefined;
 
-  useShipmentOptionsState(
-    form,
-    allOptionKeys,
-    proxyQueries && orderId ? {orderId, selection: proxyQueries.selection} : undefined,
-  );
+  useShipmentOptionsState(form, allOptionKeys, shipmentQuery);
 
-  if (proxyQueries && orderId) {
-    useCapabilitiesAutoClear(form, allOptionKeys, orderId, order.inheritedDeliveryOptions, proxyQueries.selection);
+  if (shipmentQuery) {
+    useCapabilitiesAutoClear(
+      form,
+      allOptionKeys,
+      shipmentQuery.orderId,
+      order.inheritedDeliveryOptions,
+      shipmentQuery.selection,
+    );
   }
 };
 
@@ -104,13 +107,9 @@ const wireCapabilitiesBehavior = (
  * Collect the union of all option keys across all carriers from the dynamic context.
  *
  * Fields are created for every unique option key so they exist when the user
- * switches carriers. Visibility and disabled state are controlled by
- * `hasShipmentOption`, which checks whether the currently selected carrier
- * supports each option.
- *
- * Runtime carrier-specific data (isRequired, insuredAmount, etc.) is read
- * from the currently selected carrier via `getCarrier(form)`, not from
- * creation-time option data.
+ * switches carriers. Visibility, disabled state and locking are resolved per
+ * option by the option-state module (`useShipmentOptionsState`) for whichever
+ * carrier is currently selected — not from creation-time option data.
  */
 const collectAllOptionKeys = (carriers: {options?: Record<string, unknown> | null}[]): string[] => {
   const keys = new Set<string>();
@@ -147,7 +146,7 @@ const buildDynamicRefs = (order: Plugin.ModelContextOrderDataContext, optionKeys
 
   // Dynamic shipment option refs from carrier options
   for (const key of optionKeys) {
-    const fieldName = `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
+    const fieldName = optionFieldName(key);
     refs[fieldName] = get(order, fieldName);
   }
 
@@ -171,7 +170,7 @@ const createShipmentOptionsFields = (
 
   // Dynamic shipment option fields — driven by carrier.options
   const dynamicFields = optionKeys.map((key) => {
-    const fieldName = `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
+    const fieldName = optionFieldName(key);
     const factory = fieldFactoryRegistry[key];
 
     if (factory) {

--- a/apps/admin/src/forms/shipmentOptions/field.ts
+++ b/apps/admin/src/forms/shipmentOptions/field.ts
@@ -45,3 +45,9 @@ export const FIELD_WIDTH: FieldName = `${PHYSICAL_PROPERTIES_PREFIX}.${WIDTH}`;
 export const FIELD_HEIGHT: FieldName = `${PHYSICAL_PROPERTIES_PREFIX}.${HEIGHT}`;
 
 export const FIELD_SHIPMENT_OPTIONS_PREFIX: FieldName = `${DELIVERY_OPTIONS_PREFIX}.${SHIPMENT_OPTIONS}`;
+
+/**
+ * Full field name of a shipment option, from its capability option key
+ * (e.g. `requiresSignature` → `deliveryOptions.shipmentOptions.requiresSignature`).
+ */
+export const optionFieldName = (optionKey: string): FieldName => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${optionKey}`;

--- a/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.spec.ts
@@ -1,0 +1,64 @@
+import {describe, expect, it, vi} from 'vitest';
+import {type FormInstance} from '@myparcel-dev/vue-form-builder';
+import {type OptionState} from '../useShipmentOptionsState';
+import {createInsuranceField} from './createInsuranceField';
+
+/** Mutable option state — tests set this to control what the option-state module resolves. */
+let mockState: OptionState;
+
+vi.mock('../useShipmentOptionsState', () => ({
+  getOptionState: () => mockState,
+}));
+
+// Full mock (no importOriginal) to avoid the Vue file import chain
+// that triggers "Install @vitejs/plugin-vue" errors.
+vi.mock('../../helpers', () => ({
+  resolveFormComponent: () => 'MockSelectInput',
+  defineFormField: (config: Record<string, unknown>) => config,
+  getFieldLabel: (name: string) => name,
+  setFieldProp: vi.fn(),
+  useFormCapabilities: () => ({
+    getCarrierCapabilitiesForShipment: () => undefined,
+    getInsuranceOptions: () => [],
+  }),
+}));
+
+vi.mock('../../../composables', () => ({
+  useLocalizedFormatter: () => ({}),
+}));
+
+const state = (overrides: Partial<OptionState>): OptionState => ({
+  supported: true,
+  readOnly: false,
+  forcedOn: false,
+  forcedOff: false,
+  ...overrides,
+});
+
+const form = {} as FormInstance;
+
+describe('createInsuranceField', () => {
+  const fieldName = 'deliveryOptions.shipmentOptions.insurance';
+
+  const isReadOnly = (optionState: OptionState): boolean => {
+    mockState = optionState;
+
+    const field = createInsuranceField({[fieldName]: undefined}, fieldName);
+
+    return (field.readOnlyWhen as (context: {form: FormInstance}) => boolean)({form});
+  };
+
+  it('locks the amount when the option is excluded', () => {
+    // A rule that excludes the option gives one valid amount. The user has no other choice.
+    expect(isReadOnly(state({forcedOff: true, readOnly: true}))).toBe(true);
+  });
+
+  it('keeps the amount editable when the option is required', () => {
+    // A rule that requires the option gives a range of amounts. The user must set one of them.
+    expect(isReadOnly(state({forcedOn: true, readOnly: true}))).toBe(false);
+  });
+
+  it('keeps the amount editable when no rule applies', () => {
+    expect(isReadOnly(state({}))).toBe(false);
+  });
+});

--- a/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
@@ -18,15 +18,12 @@ import {createRef} from './createRef';
  * packageType / deliveryType / weight / cc change, since those all narrow the shipment-scoped
  * capabilities response.
  *
- * Visibility / disabled state is inherited from {@link createShipmentOptionField} — driven
- * purely by `hasShipmentOption` (i.e. by the capabilities response). No manual package-type
+ * Visibility / disabled state is inherited from {@link createShipmentOptionField} — resolved
+ * by the option-state module from the capabilities response. No manual package-type
  * gating: if insurance isn't valid for the current combination, the API won't include it in
  * `carrier.options` and the field will hide.
  */
-export const createInsuranceField = (
-  refs: ShipmentOptionsRefs,
-  fieldName: string,
-): InteractiveElementConfiguration => {
+export const createInsuranceField = (refs: ShipmentOptionsRefs, fieldName: string): InteractiveElementConfiguration => {
   const formatter = useLocalizedFormatter();
   const capabilities = useFormCapabilities();
   let stopWatcher: (() => void) | undefined;

--- a/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
@@ -1,5 +1,6 @@
 import {watch} from 'vue';
 import {type InteractiveElementConfiguration} from '@myparcel-dev/vue-form-builder';
+import {getOptionState} from '../useShipmentOptionsState';
 import {type ShipmentOptionsRefs} from '../types';
 import {PROP_OPTIONS} from '../field';
 import {resolveFormComponent, setFieldProp, useFormCapabilities} from '../../helpers';
@@ -26,11 +27,17 @@ import {createRef} from './createRef';
 export const createInsuranceField = (refs: ShipmentOptionsRefs, fieldName: string): InteractiveElementConfiguration => {
   const formatter = useLocalizedFormatter();
   const capabilities = useFormCapabilities();
+  const optionKey = fieldName.split('.').pop() ?? fieldName;
   let stopWatcher: (() => void) | undefined;
 
   return createShipmentOptionField(refs, fieldName, {
     ref: createRef(refs, fieldName, 0),
     component: resolveFormComponent(AdminComponent.SelectInput),
+
+    // The field holds a range of amounts. A rule that requires insurance does not give one
+    // amount, and thus the user keeps control of the field. A rule that excludes insurance gives
+    // one amount, and the field is then read-only.
+    readOnlyWhen: ({form}) => getOptionState(form, optionKey).forcedOff,
     onBeforeMount(field: ElementInstance) {
       stopWatcher?.();
 

--- a/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.spec.ts
@@ -1,14 +1,18 @@
 import {describe, expect, it, vi} from 'vitest';
-import {ref} from 'vue';
-import {TriState} from '@myparcel-dev/pdk-common';
-import {type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
+import {type FormInstance} from '@myparcel-dev/vue-form-builder';
+import {type OptionState} from '../useShipmentOptionsState';
 import {createShipmentOptionField} from './createShipmentOptionField';
 
 /**
- * Mutable carrier context — tests set this to control what the bag's `getCarrierCapabilitiesForShipment`
- * and `hasShipmentOption` return without needing per-test mock overrides.
+ * Mutable option state — tests set this to control what the option-state module resolves for
+ * the field, without needing per-test mock overrides. The factory's hooks must be pure
+ * lookups on this state; all decision logic is covered by useShipmentOptionsState.spec.ts.
  */
-let mockCarrier: Record<string, unknown> | undefined;
+let mockState: OptionState;
+
+vi.mock('../useShipmentOptionsState', () => ({
+  getOptionState: () => mockState,
+}));
 
 // Full mock (no importOriginal) to avoid the Vue file import chain
 // that triggers "Install @vitejs/plugin-vue" errors.
@@ -16,162 +20,70 @@ vi.mock('../../helpers', () => ({
   resolveFormComponent: () => 'MockTriStateInput',
   defineFormField: (config: Record<string, unknown>) => config,
   getFieldLabel: (name: string) => name,
-  useFormCapabilities: () => ({
-    getCarrierCapabilitiesForShipment: () => mockCarrier,
-    getCarrierCapabilitiesForOrder: () => mockCarrier,
-    hasShipmentOption: (_form: unknown, option: string) => {
-      return Object.hasOwn((mockCarrier?.options as Record<string, unknown>) ?? {}, option);
-    },
-    getInsuranceOptions: () => [],
-  }),
 }));
 
-/** Create a minimal mock field instance with a reactive ref and mutable props. */
-const createMockField = (name: string, fieldValue = TriState.Inherit) => {
-  return {
-    name,
-    ref: ref(fieldValue),
-    form: {} as never,
-    props: {readOnly: false, disabled: false},
-  } as unknown as InteractiveElementInstance;
-};
+const state = (overrides: Partial<OptionState>): OptionState => ({
+  supported: true,
+  visible: true,
+  readOnly: false,
+  forcedOn: false,
+  forcedOff: false,
+  ...overrides,
+});
 
-/** Create a mock form that resolves fields by name from the given list. */
-const createMockForm = (fields: InteractiveElementInstance[]) => {
-  return {
-    getField: (name: string) => fields.find((f) => f.name === name),
-    getValue: () => undefined,
-  };
-};
+const form = {} as FormInstance;
 
 describe('createShipmentOptionField', () => {
-  const createRefs = (fieldName: string, value?: unknown) => ({[fieldName]: value});
+  const fieldName = 'deliveryOptions.shipmentOptions.requiresSignature';
 
-  it('creates a field with TriState.Inherit default', () => {
-    const fieldName = 'deliveryOptions.shipmentOptions.testOption';
-    const refs = createRefs(fieldName);
+  const createField = () => createShipmentOptionField({[fieldName]: undefined}, fieldName);
 
-    const field = createShipmentOptionField(refs, fieldName);
+  it('creates a field with the given name', () => {
+    mockState = state({});
 
-    expect(field.name).toBe(fieldName);
+    expect(createField().name).toBe(fieldName);
   });
 
-  describe('afterUpdate dependency logic', () => {
-    /**
-     * Helper that sets up a POSTNL carrier with `requires` / `excludes` declared on the
-     * `requiresAgeVerification` option (mirroring what the live capabilities response carries),
-     * the dependent fields, and a triggerAfterUpdate to invoke the just-toggled age-check field.
-     *
-     * The `requires` / `excludes` rules live directly on the option entry in the carrier model
-     * — sourced from the shipment-scoped capabilities response on the live path.
-     *
-     * @param optionOverrides - per-option overrides merged into the default carrier options
-     *   (e.g. `{ requiresSignature: { isRequired: true } }`)
-     */
-    const setupAgeVerificationScenario = (optionOverrides: Record<string, Record<string, unknown>> = {}) => {
-      const defaultOptions: Record<string, Record<string, unknown>> = {
-        requiresAgeVerification: {
-          isRequired: false,
-          isSelectedByDefault: false,
-          requires: ['recipientOnlyDelivery', 'requiresSignature'],
-          excludes: ['requiresReceiptCode'],
-        },
-        requiresSignature: {isRequired: false, isSelectedByDefault: false},
-        recipientOnlyDelivery: {isRequired: false, isSelectedByDefault: false},
-        requiresReceiptCode: {isRequired: false, isSelectedByDefault: false},
-      };
+  it('is visible and enabled when the option is supported', () => {
+    mockState = state({supported: true, visible: true});
+    const field = createField();
 
-      mockCarrier = {
-        carrier: 'POSTNL',
-        options: {...defaultOptions, ...optionOverrides},
-      };
+    expect(field.visibleWhen!.call(field, {form} as never)).toBe(true);
+    expect(field.disabledWhen!.call(field, {form} as never)).toBe(false);
+  });
 
-      const signatureField = createMockField('deliveryOptions.shipmentOptions.requiresSignature');
-      const onlyRecipientField = createMockField('deliveryOptions.shipmentOptions.recipientOnlyDelivery');
-      const receiptCodeField = createMockField('deliveryOptions.shipmentOptions.requiresReceiptCode');
-      const form = createMockForm([signatureField, onlyRecipientField, receiptCodeField]);
+  it('is hidden and disabled when the option is not supported', () => {
+    mockState = state({supported: false, visible: false});
+    const field = createField();
 
-      const fieldName = 'deliveryOptions.shipmentOptions.requiresAgeVerification';
-      const config = createShipmentOptionField(createRefs(fieldName), fieldName);
+    expect(field.visibleWhen!.call(field, {form} as never)).toBe(false);
+    expect(field.disabledWhen!.call(field, {form} as never)).toBe(true);
+  });
 
-      const triggerAfterUpdate = (value: TriState) => {
-        const ageCheckField = {
-          ...createMockField(fieldName, value),
-          form,
-        } as unknown as InteractiveElementInstance;
+  it('is read-only when the option is forced on', () => {
+    mockState = state({forcedOn: true, readOnly: true});
+    const field = createField();
 
-        config.afterUpdate!(ageCheckField, value, undefined);
-      };
+    expect(field.readOnlyWhen!.call(field, {form} as never)).toBe(true);
+  });
 
-      return {signatureField, onlyRecipientField, receiptCodeField, triggerAfterUpdate};
-    };
+  it('is read-only when the option is forced off', () => {
+    mockState = state({forcedOff: true, readOnly: true});
+    const field = createField();
 
-    // Enabling 18+ check should force signature + only-recipient ON and lock them.
-    it('forces required-dependency fields ON and readOnly when source is enabled', () => {
-      const {signatureField, onlyRecipientField, triggerAfterUpdate} = setupAgeVerificationScenario();
+    expect(field.readOnlyWhen!.call(field, {form} as never)).toBe(true);
+  });
 
-      triggerAfterUpdate(TriState.On);
+  it('is editable when nothing forces the option', () => {
+    mockState = state({});
+    const field = createField();
 
-      expect(signatureField.ref.value).toBe(TriState.On);
-      expect(signatureField.props.readOnly).toBe(true);
-      expect(onlyRecipientField.ref.value).toBe(TriState.On);
-      expect(onlyRecipientField.props.readOnly).toBe(true);
-    });
+    expect(field.readOnlyWhen!.call(field, {form} as never)).toBe(false);
+  });
 
-    // Enabling 18+ check should force receipt code OFF and lock it.
-    it('forces excluded-dependency fields OFF and readOnly when source is enabled', () => {
-      const {receiptCodeField, triggerAfterUpdate} = setupAgeVerificationScenario();
+  it('defines no afterUpdate hook — enforcement lives in the option-state module', () => {
+    mockState = state({});
 
-      triggerAfterUpdate(TriState.On);
-
-      expect(receiptCodeField.ref.value).toBe(TriState.Off);
-      expect(receiptCodeField.props.readOnly).toBe(true);
-    });
-
-    // Disabling 18+ check should unlock dependent fields so the user can edit them again.
-    it('clears readOnly on dependent fields when source is disabled', () => {
-      const {signatureField, onlyRecipientField, receiptCodeField, triggerAfterUpdate} =
-        setupAgeVerificationScenario();
-
-      // First enable to lock the fields…
-      triggerAfterUpdate(TriState.On);
-      // …then disable to unlock them.
-      triggerAfterUpdate(TriState.Off);
-
-      expect(signatureField.props.readOnly).toBe(false);
-      expect(onlyRecipientField.props.readOnly).toBe(false);
-      expect(receiptCodeField.props.readOnly).toBe(false);
-    });
-
-    // When the carrier independently requires an option (isRequired: true), disabling the
-    // dependency source must NOT clear that field's readOnly or change its value. Regression:
-    // previously, turning off 18+ check would blindly set readOnly = false on all dependents,
-    // overriding the carrier's isRequired lock.
-    it('preserves readOnly and value on carrier-required fields when dependency source is disabled', () => {
-      const {signatureField, onlyRecipientField, receiptCodeField, triggerAfterUpdate} =
-        setupAgeVerificationScenario({
-          // Signature is independently required by the carrier
-          requiresSignature: {isRequired: true, isSelectedByDefault: false},
-        });
-
-      // First enable to lock all dependent fields…
-      triggerAfterUpdate(TriState.On);
-
-      // Verify signature was forced ON by the dependency.
-      expect(signatureField.ref.value).toBe(TriState.On);
-      expect(signatureField.props.readOnly).toBe(true);
-
-      // …then disable — signature should stay locked and ON, others should unlock.
-      triggerAfterUpdate(TriState.Off);
-
-      // Signature must remain ON and readOnly because the carrier requires it, regardless of
-      // the 18+ dependency being turned off.
-      expect(signatureField.ref.value).toBe(TriState.On);
-      expect(signatureField.props.readOnly).toBe(true);
-      // Only-recipient is not independently required, so it should unlock.
-      expect(onlyRecipientField.props.readOnly).toBe(false);
-      // Receipt code is an excluded dep, also not independently required.
-      expect(receiptCodeField.props.readOnly).toBe(false);
-    });
+    expect(createField().afterUpdate).toBeUndefined();
   });
 });

--- a/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.spec.ts
@@ -24,7 +24,6 @@ vi.mock('../../helpers', () => ({
 
 const state = (overrides: Partial<OptionState>): OptionState => ({
   supported: true,
-  visible: true,
   readOnly: false,
   forcedOn: false,
   forcedOff: false,
@@ -45,7 +44,7 @@ describe('createShipmentOptionField', () => {
   });
 
   it('is visible and enabled when the option is supported', () => {
-    mockState = state({supported: true, visible: true});
+    mockState = state({supported: true});
     const field = createField();
 
     expect(field.visibleWhen!.call(field, {form} as never)).toBe(true);
@@ -53,22 +52,15 @@ describe('createShipmentOptionField', () => {
   });
 
   it('is hidden and disabled when the option is not supported', () => {
-    mockState = state({supported: false, visible: false});
+    mockState = state({supported: false});
     const field = createField();
 
     expect(field.visibleWhen!.call(field, {form} as never)).toBe(false);
     expect(field.disabledWhen!.call(field, {form} as never)).toBe(true);
   });
 
-  it('is read-only when the option is forced on', () => {
+  it('is read-only when the state says so', () => {
     mockState = state({forcedOn: true, readOnly: true});
-    const field = createField();
-
-    expect(field.readOnlyWhen!.call(field, {form} as never)).toBe(true);
-  });
-
-  it('is read-only when the option is forced off', () => {
-    mockState = state({forcedOff: true, readOnly: true});
     const field = createField();
 
     expect(field.readOnlyWhen!.call(field, {form} as never)).toBe(true);

--- a/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.ts
@@ -36,7 +36,7 @@ export const createShipmentOptionField = (
     component: resolveFormComponent(AdminComponent.TriStateInput),
     ref: createRef(refs, fieldName, TriState.Inherit),
     label: getFieldLabel(name),
-    visibleWhen: ({form}) => getOptionState(form, name).visible,
+    visibleWhen: ({form}) => getOptionState(form, name).supported,
     disabledWhen: ({form}) => !getOptionState(form, name).supported,
     readOnlyWhen: ({form}) => getOptionState(form, name).readOnly,
 

--- a/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createShipmentOptionField.ts
@@ -1,9 +1,8 @@
-import {type InteractiveElementConfiguration, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
+import {type InteractiveElementConfiguration} from '@myparcel-dev/vue-form-builder';
 import {TriState} from '@myparcel-dev/pdk-common';
+import {getOptionState} from '../useShipmentOptionsState';
 import {type ShipmentOptionsRefs} from '../types';
-import {FIELD_SHIPMENT_OPTIONS_PREFIX} from '../field';
-import {defineFormField, getFieldLabel, resolveFormComponent, useFormCapabilities} from '../../helpers';
-import {setFieldRef} from '../../form-builder/utils/createValueSetter';
+import {defineFormField, getFieldLabel, resolveFormComponent} from '../../helpers';
 import {AdminComponent} from '../../../data';
 import {createRef} from './createRef';
 
@@ -11,13 +10,19 @@ import {createRef} from './createRef';
  * Creates a generic shipment option field as a TriState toggle.
  *
  * Default factory for any option from `carrier.options` that doesn't have a custom factory in
- * `fieldFactoryRegistry`. `requires` / `excludes` are sourced from the shipment-scoped
- * response (`getCarrierCapabilitiesForShipment`); they're absent while the shipment query is loading or
- * falling back to order-level data — locking doesn't run during those windows.
+ * `fieldFactoryRegistry`.
  *
- * `useFormCapabilities()` is called at factory invocation (setup-time) so visibility, disabled,
- * readOnly and afterUpdate handlers close over a captured Pinia store + orderId — no
- * `inject()` calls during form-builder's watchEffect-driven re-evaluators.
+ * All availability and locking decisions live in the option-state module
+ * ({@link getOptionState} / `useShipmentOptionsState`) — the hooks below only read the
+ * resolved state. Locked fields use readOnly, not disabled, so their value is included in the
+ * form body by `getEnabledValues()` and persists on the order.
+ *
+ * @param refs - Initial values for all form fields, keyed by full field name (built by
+ *   `buildDynamicRefs` from the order's stored data). The field's own initial value is read
+ *   from `refs[fieldName]`.
+ * @param fieldName - The full field name including prefix, e.g.
+ *   `deliveryOptions.shipmentOptions.requiresSignature`.
+ * @param config - Optional field configuration overrides, merged over the defaults built here.
  */
 export const createShipmentOptionField = (
   refs: ShipmentOptionsRefs,
@@ -25,82 +30,15 @@ export const createShipmentOptionField = (
   config?: Partial<InteractiveElementConfiguration>,
 ): InteractiveElementConfiguration => {
   const name = fieldName.split('.').pop() ?? fieldName;
-  const capabilities = useFormCapabilities();
 
   return defineFormField({
     name: fieldName,
     component: resolveFormComponent(AdminComponent.TriStateInput),
     ref: createRef(refs, fieldName, TriState.Inherit),
     label: getFieldLabel(name),
-    visibleWhen: ({form}) => capabilities.hasShipmentOption(form, name),
-    // Disabled when the carrier doesn't support this option.
-    // Required options use readOnlyWhen instead, keeping them enabled
-    // so their value is included in the form body by getEnabledValues().
-    disabledWhen: ({form}) => !capabilities.hasShipmentOption(form, name),
-    // Read-only prevents the TriState "inherit" toggle from being used,
-    // fully locking the field when the carrier requires this option.
-    readOnlyWhen: ({form}) => {
-      return capabilities.getCarrierCapabilitiesForShipment(form)?.options?.[name]?.isRequired === true;
-    },
-
-    afterUpdate(field, value) {
-      const carrier = capabilities.getCarrierCapabilitiesForShipment(field.form);
-      const option = carrier?.options?.[name];
-
-      if (!option) {
-        return;
-      }
-
-      // Enforce isRequired: revert any user change back to TriState.On.
-      if (option.isRequired === true && value !== TriState.On) {
-        setFieldRef(field, TriState.On);
-
-        return;
-      }
-
-      const isEnabled = TriState.On === value;
-
-      for (const requiredOption of option.requires ?? []) {
-        const targetFieldName = `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${requiredOption}`;
-        const targetField = field.form.getField(targetFieldName);
-
-        if (!targetField) {
-          continue;
-        }
-
-        if (isEnabled) {
-          setFieldRef(targetField as InteractiveElementInstance, TriState.On);
-          targetField.props.readOnly = true;
-        } else {
-          // Only clear readOnly if the carrier doesn't independently require this option.
-          const isRequiredByCarrier = carrier?.options?.[requiredOption]?.isRequired === true;
-
-          if (!isRequiredByCarrier) {
-            targetField.props.readOnly = false;
-          }
-        }
-      }
-
-      for (const excludedOption of option.excludes ?? []) {
-        const targetFieldName = `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${excludedOption}`;
-        const targetField = field.form.getField(targetFieldName);
-
-        if (!targetField) {
-          continue;
-        }
-
-        if (isEnabled) {
-          setFieldRef(targetField as InteractiveElementInstance, TriState.Off);
-          targetField.props.readOnly = true;
-        } else {
-          const isRequiredByCarrier = carrier?.options?.[excludedOption]?.isRequired === true;
-
-          if (!isRequiredByCarrier) {
-            targetField.props.readOnly = false;
-          }
-        }
-      }
-    },
+    visibleWhen: ({form}) => getOptionState(form, name).visible,
+    disabledWhen: ({form}) => !getOptionState(form, name).supported,
+    readOnlyWhen: ({form}) => getOptionState(form, name).readOnly,
 
     ...config,
   });

--- a/apps/admin/src/forms/shipmentOptions/readShipmentSnapshot.ts
+++ b/apps/admin/src/forms/shipmentOptions/readShipmentSnapshot.ts
@@ -1,0 +1,56 @@
+import {toValue, type Ref} from 'vue';
+import {BackendEndpoint, type CarrierModel} from '@myparcel-dev/pdk-common';
+import {type useQueryStore} from '../../stores';
+import {type CapabilitiesSelection} from './wireProxyCapabilities';
+
+export type ShipmentResponseSnapshot =
+  | {state: 'pending'}
+  | {state: 'invalid_combo'}
+  | {state: 'matched'; carrier: CarrierModel};
+
+/**
+ * Read the shipment query's state directly so consumers can distinguish three cases the
+ * helper-level `getCarrierCapabilitiesForShipment` collapses:
+ *
+ * - **`pending`**: query not registered, loading, errored, or has no data yet. A temporary
+ *   state — consumers should wait and change nothing. Errored requests are logged via
+ *   `globalLogger.error` inside the query composable; the form keeps its current selection
+ *   rather than blocking the merchant on an intermittent failure.
+ * - **`invalid_combo`**: query is `success` but `results` is empty or doesn't contain the
+ *   chosen carrier. The server has confirmed this combination isn't valid.
+ * - **`matched`**: query is `success` and the carrier was found. The response's narrow
+ *   `options` carry the per-option metadata (`isRequired`, `requires`, `excludes`).
+ *
+ * @param selection - The debounced selection the shipment query was last fetched for, as
+ *   returned by `wireProxyCapabilities`. Its carrier decides which response entry counts as
+ *   a match.
+ * @param queryStore - The query store instance, captured at setup time by the caller (calling
+ *   `useQueryStore()` inside watcher callbacks is not allowed).
+ * @param orderId - The order's external identifier; the shipment query is registered in the
+ *   query store under `<orderId>.shipment`.
+ */
+export const readShipmentSnapshot = (
+  selection: Readonly<Ref<CapabilitiesSelection>>,
+  queryStore: ReturnType<typeof useQueryStore>,
+  orderId: string,
+): ShipmentResponseSnapshot => {
+  const modifier = `${orderId}.shipment`;
+
+  if (!queryStore.has(BackendEndpoint.ProxyCapabilities, modifier)) return {state: 'pending'};
+
+  const query = queryStore.get(BackendEndpoint.ProxyCapabilities, modifier);
+
+  if (toValue(query.status) !== 'success') return {state: 'pending'};
+
+  const carriers = toValue(query.data) ?? [];
+  // Compare against the carrier from the *debounced* selection — the same selection the
+  // shipment query was last fetched for. Reading directly from `form.getValue(carrier)` here
+  // would race: when the user just changed an axis, the form value updates immediately while
+  // the debounced selection (and thus the query's data) lags by `DEBOUNCE_MS`. During that
+  // window we'd compare the new form carrier against the previous-fetch's response, see no
+  // match, and falsely declare invalid_combo.
+  const queryCarrier = selection.value.carrier;
+  const matched = carriers.find((carrier) => carrier.carrier === queryCarrier);
+
+  return matched ? {state: 'matched', carrier: matched} : {state: 'invalid_combo'};
+};

--- a/apps/admin/src/forms/shipmentOptions/useCapabilitiesAutoClear.ts
+++ b/apps/admin/src/forms/shipmentOptions/useCapabilitiesAutoClear.ts
@@ -1,7 +1,7 @@
-import {toValue, watch, type Ref} from 'vue';
+import {watch, type Ref} from 'vue';
 import {snakeCase} from 'lodash-unified';
 import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
-import {BackendEndpoint, type CarrierModel, type Plugin, TriState} from '@myparcel-dev/pdk-common';
+import {type Plugin, TriState} from '@myparcel-dev/pdk-common';
 import {
   addCapabilitiesClearNotification,
   CAPABILITIES_CLEARED_NOTIFICATION_ID,
@@ -11,6 +11,7 @@ import {setFieldRef} from '../form-builder/utils/createValueSetter';
 import {useLanguage} from '../../composables';
 import {useNotificationStore, useQueryStore} from '../../stores';
 import {type CapabilitiesSelection} from './wireProxyCapabilities';
+import {readShipmentSnapshot} from './readShipmentSnapshot';
 import {
   FIELD_CARRIER,
   FIELD_DELIVERY_TYPE,
@@ -53,51 +54,6 @@ const setFieldValue = (form: FormInstance, fieldName: string, value: string | nu
   if (!field) return;
 
   setFieldRef(field, value as Parameters<typeof setFieldRef>[1]);
-};
-
-type ShipmentResponseSnapshot =
-  | {state: 'pending'}
-  | {state: 'invalid_combo'}
-  | {state: 'matched'; carrier: CarrierModel};
-
-/**
- * Read the shipment query's state directly so the auto-clear can distinguish three cases the
- * helper-level `getCarrierCapabilitiesForShipment` collapses for its consumers:
- *
- * - **`pending`**: query not registered, loading, errored, or has no data yet. No clear should
- *   fire — transient state. Errored requests are logged via `globalLogger.error` inside the
- *   query composable; the form keeps its current selection rather than blocking the merchant
- *   on an intermittent failure.
- * - **`invalid_combo`**: query is `success` but `results` is empty or doesn't contain the
- *   chosen carrier. The server has confirmed this combination isn't valid; trigger an
- *   axis-rollback.
- * - **`matched`**: query is `success` and the carrier was found. Use the response's narrow
- *   `options` to decide which active option fields are now orphaned.
- */
-const readShipmentSnapshot = (
-  selection: Readonly<Ref<CapabilitiesSelection>>,
-  queryStore: ReturnType<typeof useQueryStore>,
-  orderId: string,
-): ShipmentResponseSnapshot => {
-  const modifier = `${orderId}.shipment`;
-
-  if (!queryStore.has(BackendEndpoint.ProxyCapabilities, modifier)) return {state: 'pending'};
-
-  const query = queryStore.get(BackendEndpoint.ProxyCapabilities, modifier);
-
-  if (toValue(query.status) !== 'success') return {state: 'pending'};
-
-  const carriers = (toValue(query.data) ?? []) as CarrierModel[];
-  // Compare against the carrier from the *debounced* selection — the same selection the
-  // shipment query was last fetched for. Reading directly from `form.getValue(carrier)` here
-  // would race: when the user just changed an axis, the form value updates immediately while
-  // the debounced selection (and thus the query's data) lags by `DEBOUNCE_MS`. During that
-  // window we'd compare the new form carrier against the previous-fetch's response, see no
-  // match, and falsely declare invalid_combo.
-  const queryCarrier = selection.value.carrier;
-  const matched = carriers.find((carrier) => carrier.carrier === queryCarrier);
-
-  return matched ? {state: 'matched', carrier: matched} : {state: 'invalid_combo'};
 };
 
 /**

--- a/apps/admin/src/forms/shipmentOptions/useCapabilitiesAutoClear.ts
+++ b/apps/admin/src/forms/shipmentOptions/useCapabilitiesAutoClear.ts
@@ -2,23 +2,13 @@ import {watch, type Ref} from 'vue';
 import {snakeCase} from 'lodash-unified';
 import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
 import {type Plugin, TriState} from '@myparcel-dev/pdk-common';
-import {
-  addCapabilitiesClearNotification,
-  CAPABILITIES_CLEARED_NOTIFICATION_ID,
-  useFormCapabilities,
-} from '../helpers';
+import {addCapabilitiesClearNotification, CAPABILITIES_CLEARED_NOTIFICATION_ID, useFormCapabilities} from '../helpers';
 import {setFieldRef} from '../form-builder/utils/createValueSetter';
-import {useLanguage} from '../../composables';
 import {useNotificationStore, useQueryStore} from '../../stores';
+import {useLanguage} from '../../composables';
 import {type CapabilitiesSelection} from './wireProxyCapabilities';
 import {readShipmentSnapshot} from './readShipmentSnapshot';
-import {
-  FIELD_CARRIER,
-  FIELD_DELIVERY_TYPE,
-  FIELD_PACKAGE_TYPE,
-  FIELD_SHIPMENT_OPTIONS_PREFIX,
-  SHIPMENT_OPTIONS,
-} from './field';
+import {FIELD_CARRIER, FIELD_DELIVERY_TYPE, FIELD_PACKAGE_TYPE, optionFieldName, SHIPMENT_OPTIONS} from './field';
 
 type InheritedDeliveryOptions = Plugin.ModelContextOrderDataContext['inheritedDeliveryOptions'];
 
@@ -33,8 +23,6 @@ const FIELD_TO_LABEL_KEY: Record<AxisField, string> = {
   [FIELD_PACKAGE_TYPE]: snakeCase(`${SHIPMENT_OPTIONS}_package_type`),
   [FIELD_DELIVERY_TYPE]: snakeCase(`${SHIPMENT_OPTIONS}_delivery_type`),
 };
-
-const optionFieldName = (key: string): string => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
 
 /**
  * Translation key for an option's field label (matches `getFieldLabel(name)` from the
@@ -242,6 +230,7 @@ export const useCapabilitiesAutoClear = (
     if (pkgDefault !== undefined) {
       setSilently(FIELD_PACKAGE_TYPE, pkgDefault as string | number | boolean | undefined);
     }
+
     if (dtDefault !== undefined) {
       setSilently(FIELD_DELIVERY_TYPE, dtDefault as string | number | boolean | undefined);
     }
@@ -393,6 +382,7 @@ export const useCapabilitiesAutoClear = (
         const isActive = value !== undefined && value !== TriState.Inherit && Boolean(value);
 
         if (!isActive) continue;
+
         if (availableOptionKeys.includes(optionKey)) continue;
 
         setSilently(fieldName, TriState.Inherit);

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
@@ -1,0 +1,475 @@
+import {effectScope, nextTick, ref, type Ref} from 'vue';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {BackendEndpoint, type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
+import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
+
+type FakeQuery = {
+  status: ReturnType<typeof ref<string>>;
+  data: ReturnType<typeof ref<unknown>>;
+};
+
+const queries = new Map<string, FakeQuery>();
+
+const queryStoreMock = {
+  has: (endpoint: BackendEndpoint, modifier: string) => queries.has(`${endpoint}.${modifier}`),
+  get: (endpoint: BackendEndpoint, modifier: string) =>
+    queries.get(`${endpoint}.${modifier}`) ?? {status: ref('idle'), data: ref(undefined)},
+};
+
+const registerShipmentQuery = (orderId: string): FakeQuery => {
+  const entry: FakeQuery = {status: ref('loading'), data: ref(undefined)};
+
+  queries.set(`${BackendEndpoint.ProxyCapabilities}.${orderId}.shipment`, entry);
+
+  return entry;
+};
+
+const getCarrierCapabilitiesForShipmentMock = vi.fn();
+
+vi.mock('../../stores', () => ({
+  useQueryStore: () => queryStoreMock,
+}));
+
+vi.mock('../helpers', () => ({
+  useFormCapabilities: () => ({
+    getCarrierCapabilitiesForShipment: getCarrierCapabilitiesForShipmentMock,
+  }),
+}));
+
+const setFieldRefMock = vi.fn();
+
+vi.mock('../form-builder/utils/createValueSetter', () => ({
+  setFieldRef: setFieldRefMock,
+}));
+
+const optionFieldName = (key: string): string => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
+
+type FakeField = {name: string; ref: Ref<unknown>; props: {defaultValue?: TriState}};
+
+const buildForm = (initial: Record<string, unknown>, defaults: Record<string, TriState> = {}) => {
+  const fieldByName = new Map<string, FakeField>();
+
+  Object.keys(initial).forEach((name) => {
+    fieldByName.set(name, {name, ref: ref(initial[name]), props: {defaultValue: defaults[name]}});
+  });
+
+  return {
+    state: new Proxy({} as Record<string, unknown>, {
+      get: (_, name: string) => fieldByName.get(name)?.ref.value,
+    }),
+    getValue: <T>(name: string): T => fieldByName.get(name)?.ref.value as T,
+    getField: (name: string) => {
+      if (!fieldByName.has(name)) {
+        fieldByName.set(name, {name, ref: ref(undefined), props: {}});
+      }
+
+      return fieldByName.get(name);
+    },
+    setExternally: (name: string, value: unknown) => {
+      const field = fieldByName.get(name);
+
+      if (field) {
+        field.ref.value = value;
+      } else {
+        fieldByName.set(name, {name, ref: ref(value), props: {}});
+      }
+    },
+  };
+};
+
+const wireSetFieldRef = (form: ReturnType<typeof buildForm>) => {
+  setFieldRefMock.mockImplementation((field: {name: string}, value: unknown) => {
+    form.setExternally(field.name, value);
+  });
+};
+
+/** Real PostNL shape: 18+ requires signature + only recipient and excludes receipt code. */
+const realOptions = (): CarrierModel['options'] =>
+  ({
+    requiresAgeVerification: {
+      isRequired: false,
+      isSelectedByDefault: false,
+      requires: ['recipientOnlyDelivery', 'requiresSignature'],
+      excludes: ['requiresReceiptCode'],
+    },
+    requiresSignature: {isRequired: false, isSelectedByDefault: false},
+    recipientOnlyDelivery: {isRequired: false, isSelectedByDefault: false},
+    requiresReceiptCode: {isRequired: false, isSelectedByDefault: false},
+  } as CarrierModel['options']);
+
+const ALL_KEYS = ['requiresAgeVerification', 'requiresSignature', 'recipientOnlyDelivery', 'requiresReceiptCode'];
+
+const buildCarrier = (overrides: Partial<CarrierModel>): CarrierModel =>
+  ({
+    carrier: 'POSTNL',
+    packageTypes: [],
+    deliveryTypes: [],
+    options: {},
+    ...overrides,
+  } as CarrierModel);
+
+beforeEach(() => {
+  queries.clear();
+  getCarrierCapabilitiesForShipmentMock.mockReset();
+  setFieldRefMock.mockReset();
+});
+
+describe('resolveOptionStates (pure)', () => {
+  const entry = (key: string, value?: TriState, defaultValue?: TriState) => ({key, value, defaultValue});
+
+  it('forces the requires closure of an enabled option on and locks it', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const states = resolveOptionStates({
+      availabilityOptions: realOptions(),
+      shipmentOptions: realOptions(),
+      entries: [
+        entry('requiresAgeVerification', TriState.On),
+        entry('requiresSignature', TriState.Inherit),
+        entry('recipientOnlyDelivery', TriState.Off),
+        entry('requiresReceiptCode', TriState.Inherit),
+      ],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true, targetValue: TriState.On});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({
+      forcedOn: true,
+      readOnly: true,
+      targetValue: TriState.On,
+    });
+    expect(states.get('requiresReceiptCode')).toMatchObject({
+      forcedOff: true,
+      readOnly: true,
+      targetValue: TriState.Off,
+    });
+    // The source option itself is not forced; its own value is user intent.
+    expect(states.get('requiresAgeVerification')).toMatchObject({forcedOn: false, readOnly: false});
+  });
+
+  it('treats inherit with an inherited default of on as enabled', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const states = resolveOptionStates({
+      availabilityOptions: realOptions(),
+      shipmentOptions: realOptions(),
+      entries: [
+        entry('requiresAgeVerification', TriState.Inherit, TriState.On),
+        entry('requiresSignature', TriState.Inherit),
+        entry('recipientOnlyDelivery', TriState.Inherit),
+        entry('requiresReceiptCode', TriState.Inherit),
+      ],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, targetValue: TriState.On});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true, targetValue: TriState.On});
+  });
+
+  it('seeds carrier-required options into the forced set including their requires', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const options = {
+      requiresSignature: {isRequired: true, requires: ['recipientOnlyDelivery']},
+      recipientOnlyDelivery: {isRequired: false},
+    } as unknown as CarrierModel['options'];
+
+    const states = resolveOptionStates({
+      availabilityOptions: options,
+      shipmentOptions: options,
+      entries: [entry('requiresSignature', TriState.Inherit), entry('recipientOnlyDelivery', TriState.Inherit)],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true, targetValue: TriState.On});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true, targetValue: TriState.On});
+  });
+
+  it('resolves transitive requires chains', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const options = {
+      optionA: {requires: ['optionB']},
+      optionB: {requires: ['optionC']},
+      optionC: {},
+    } as unknown as CarrierModel['options'];
+
+    const states = resolveOptionStates({
+      availabilityOptions: options,
+      shipmentOptions: options,
+      entries: [entry('optionA', TriState.On), entry('optionB', TriState.Inherit), entry('optionC', TriState.Inherit)],
+    });
+
+    expect(states.get('optionB')).toMatchObject({forcedOn: true});
+    expect(states.get('optionC')).toMatchObject({forcedOn: true});
+  });
+
+  it('terminates on circular requires', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const options = {
+      optionA: {requires: ['optionB']},
+      optionB: {requires: ['optionA']},
+    } as unknown as CarrierModel['options'];
+
+    const states = resolveOptionStates({
+      availabilityOptions: options,
+      shipmentOptions: options,
+      entries: [entry('optionA', TriState.On), entry('optionB', TriState.Inherit)],
+    });
+
+    expect(states.get('optionB')).toMatchObject({forcedOn: true});
+  });
+
+  it('lets forced-off win over forced-on', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const options = {
+      optionA: {requires: ['optionC']},
+      optionB: {excludes: ['optionC']},
+      optionC: {},
+    } as unknown as CarrierModel['options'];
+
+    const states = resolveOptionStates({
+      availabilityOptions: options,
+      shipmentOptions: options,
+      entries: [entry('optionA', TriState.On), entry('optionB', TriState.On), entry('optionC', TriState.Inherit)],
+    });
+
+    expect(states.get('optionC')).toMatchObject({forcedOn: false, forcedOff: true, targetValue: TriState.Off});
+  });
+
+  it('marks options missing from availability data as unsupported and hidden', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const options = {requiresSignature: {}} as unknown as CarrierModel['options'];
+
+    const states = resolveOptionStates({
+      availabilityOptions: options,
+      shipmentOptions: options,
+      entries: [entry('requiresSignature', TriState.Inherit), entry('hideSender', TriState.Inherit)],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({supported: true, visible: true});
+    expect(states.get('hideSender')).toMatchObject({supported: false, visible: false});
+  });
+
+  it('produces no locks and no coercions without rule data', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const states = resolveOptionStates({
+      availabilityOptions: realOptions(),
+      shipmentOptions: undefined,
+      entries: [entry('requiresAgeVerification', TriState.On), entry('requiresSignature', TriState.Off)],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: false, forcedOff: false, readOnly: false});
+    expect(states.get('requiresSignature')?.targetValue).toBeUndefined();
+  });
+
+  it('marks everything unsupported without availability data', async () => {
+    const {resolveOptionStates} = await import('./useShipmentOptionsState');
+
+    const states = resolveOptionStates({
+      availabilityOptions: undefined,
+      shipmentOptions: undefined,
+      entries: [entry('requiresSignature', TriState.Inherit)],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({supported: false, visible: false});
+  });
+});
+
+describe('useShipmentOptionsState (reactive)', () => {
+  const setup = async (
+    initialValues: Record<string, unknown>,
+    defaults: Record<string, TriState> = {},
+    selectionCarrier = 'POSTNL',
+  ) => {
+    const form = buildForm({[FIELD_CARRIER]: 'POSTNL', ...initialValues}, defaults);
+
+    wireSetFieldRef(form);
+
+    const shipmentEntry = registerShipmentQuery('order-1');
+    const selection = ref({carrier: selectionCarrier, packageType: 'PACKAGE', deliveryType: 'STANDARD'}) as Ref<{
+      carrier?: string;
+      packageType?: string;
+      deliveryType?: string;
+    }>;
+
+    const scope = effectScope();
+    const {useShipmentOptionsState, getOptionState} = await import('./useShipmentOptionsState');
+
+    scope.run(() => {
+      useShipmentOptionsState(form as never, ALL_KEYS, {orderId: 'order-1', selection});
+    });
+
+    return {form, shipmentEntry, selection, scope, getOptionState};
+  };
+
+  const resolveShipment = (shipmentEntry: FakeQuery, options: CarrierModel['options']) => {
+    shipmentEntry.status.value = 'success';
+    shipmentEntry.data.value = [buildCarrier({carrier: 'POSTNL', options})];
+  };
+
+  it('turns dependent options on and locks them when the form opens with the source already on', async () => {
+    const {form, shipmentEntry, scope, getOptionState} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Off,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+    expect(form.state[optionFieldName('recipientOnlyDelivery')]).toBe(TriState.On);
+    expect(form.state[optionFieldName('requiresReceiptCode')]).toBe(TriState.Off);
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+    expect(getOptionState(form as never, 'recipientOnlyDelivery').readOnly).toBe(true);
+    expect(getOptionState(form as never, 'requiresReceiptCode').readOnly).toBe(true);
+    expect(getOptionState(form as never, 'requiresAgeVerification').readOnly).toBe(false);
+
+    scope.stop();
+  });
+
+  it('turns dependent options on and locks them when the source is on through its inherited default', async () => {
+    const {form, shipmentEntry, scope, getOptionState} = await setup(
+      {
+        [optionFieldName('requiresAgeVerification')]: TriState.Inherit,
+        [optionFieldName('requiresSignature')]: TriState.Inherit,
+        [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+        [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+      },
+      {[optionFieldName('requiresAgeVerification')]: TriState.On},
+    );
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+
+    scope.stop();
+  });
+
+  it('unlocks dependents without reverting their values when the source turns off', async () => {
+    const {form, shipmentEntry, scope, getOptionState} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+
+    form.setExternally(optionFieldName('requiresAgeVerification'), TriState.Off);
+    await nextTick();
+
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(false);
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+
+    scope.stop();
+  });
+
+  it('keeps carrier-required options locked when the dependency source turns off', async () => {
+    const options = realOptions();
+
+    (options as Record<string, {isRequired?: boolean}>).requiresSignature.isRequired = true;
+
+    const {form, shipmentEntry, scope, getOptionState} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, options);
+    await nextTick();
+
+    form.setExternally(optionFieldName('requiresAgeVerification'), TriState.Off);
+    await nextTick();
+
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+    expect(getOptionState(form as never, 'recipientOnlyDelivery').readOnly).toBe(false);
+
+    scope.stop();
+  });
+
+  it('applies no locks and writes nothing while the shipment query is loading', async () => {
+    const {scope, getOptionState, form} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+    });
+
+    await nextTick();
+
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(false);
+    expect(setFieldRefMock).not.toHaveBeenCalled();
+
+    scope.stop();
+  });
+
+  it('keeps existing locks while the same carrier is being refetched', async () => {
+    const {form, shipmentEntry, scope, getOptionState} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+
+    // Weight change: query refetches for the same carrier.
+    shipmentEntry.status.value = 'loading';
+    await nextTick();
+
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+
+    scope.stop();
+  });
+
+  it('drops locks when the form carrier no longer matches the fetched selection', async () => {
+    const {form, shipmentEntry, scope, getOptionState} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(true);
+
+    // Carrier switch: form updates instantly, debounced selection still points at POSTNL.
+    form.setExternally(FIELD_CARRIER, 'DPD');
+    await nextTick();
+
+    expect(getOptionState(form as never, 'requiresSignature').readOnly).toBe(false);
+
+    scope.stop();
+  });
+
+  it('turns a forced option back on when something else switches it off', async () => {
+    const {form, shipmentEntry, scope} = await setup({
+      [optionFieldName('requiresAgeVerification')]: TriState.On,
+      [optionFieldName('requiresSignature')]: TriState.Inherit,
+      [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
+      [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+    });
+
+    resolveShipment(shipmentEntry, realOptions());
+    await nextTick();
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+
+    form.setExternally(optionFieldName('requiresSignature'), TriState.Off);
+    await nextTick();
+
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.On);
+
+    scope.stop();
+  });
+});

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
@@ -1,7 +1,8 @@
 import {effectScope, nextTick, ref, type Ref} from 'vue';
 import {describe, expect, it, vi, beforeEach} from 'vitest';
 import {BackendEndpoint, type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
-import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
+import {getOptionState, resolveOptionStates, useShipmentOptionsState} from './useShipmentOptionsState';
+import {FIELD_CARRIER, optionFieldName} from './field';
 
 type FakeQuery = {
   status: ReturnType<typeof ref<string>>;
@@ -31,6 +32,10 @@ vi.mock('../../stores', () => ({
 }));
 
 vi.mock('../helpers', () => ({
+  // Mirrors the real triStateValueIsEnabled. Kept inline: awaiting an import inside this
+  // factory deadlocks vitest through the helpers barrel's own import chain.
+  triStateValueIsEnabled: (value: unknown, defaultValue: unknown) =>
+    value === TriState.Inherit ? defaultValue === TriState.On : value === TriState.On,
   useFormCapabilities: () => ({
     getCarrierCapabilitiesForShipment: getCarrierCapabilitiesForShipmentMock,
   }),
@@ -38,11 +43,11 @@ vi.mock('../helpers', () => ({
 
 const setFieldRefMock = vi.fn();
 
+// The extra arrow keeps the spy reference lazy: the mock factory runs while this module is
+// still initializing (static imports), before `setFieldRefMock` above exists.
 vi.mock('../form-builder/utils/createValueSetter', () => ({
-  setFieldRef: setFieldRefMock,
+  setFieldRef: (field: unknown, value: unknown) => setFieldRefMock(field, value),
 }));
-
-const optionFieldName = (key: string): string => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
 
 type FakeField = {name: string; ref: Ref<unknown>; props: {defaultValue?: TriState}};
 
@@ -117,9 +122,7 @@ beforeEach(() => {
 describe('resolveOptionStates (pure)', () => {
   const entry = (key: string, value?: TriState, defaultValue?: TriState) => ({key, value, defaultValue});
 
-  it('forces the requires closure of an enabled option on and locks it', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('forces the requires closure of an enabled option on and locks it', () => {
     const states = resolveOptionStates({
       availabilityOptions: realOptions(),
       shipmentOptions: realOptions(),
@@ -131,24 +134,20 @@ describe('resolveOptionStates (pure)', () => {
       ],
     });
 
-    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true, targetValue: TriState.On});
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true});
     expect(states.get('recipientOnlyDelivery')).toMatchObject({
       forcedOn: true,
       readOnly: true,
-      targetValue: TriState.On,
     });
     expect(states.get('requiresReceiptCode')).toMatchObject({
       forcedOff: true,
       readOnly: true,
-      targetValue: TriState.Off,
     });
     // The source option itself is not forced; its own value is user intent.
     expect(states.get('requiresAgeVerification')).toMatchObject({forcedOn: false, readOnly: false});
   });
 
-  it('treats inherit with an inherited default of on as enabled', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('treats inherit with an inherited default of on as enabled', () => {
     const states = resolveOptionStates({
       availabilityOptions: realOptions(),
       shipmentOptions: realOptions(),
@@ -160,13 +159,11 @@ describe('resolveOptionStates (pure)', () => {
       ],
     });
 
-    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, targetValue: TriState.On});
-    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true, targetValue: TriState.On});
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true});
   });
 
-  it('seeds carrier-required options into the forced set including their requires', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('seeds carrier-required options into the forced set including their requires', () => {
     const options = {
       requiresSignature: {isRequired: true, requires: ['recipientOnlyDelivery']},
       recipientOnlyDelivery: {isRequired: false},
@@ -178,13 +175,11 @@ describe('resolveOptionStates (pure)', () => {
       entries: [entry('requiresSignature', TriState.Inherit), entry('recipientOnlyDelivery', TriState.Inherit)],
     });
 
-    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true, targetValue: TriState.On});
-    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true, targetValue: TriState.On});
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: true, readOnly: true});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: true});
   });
 
-  it('resolves transitive requires chains', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('resolves transitive requires chains', () => {
     const options = {
       optionA: {requires: ['optionB']},
       optionB: {requires: ['optionC']},
@@ -201,9 +196,7 @@ describe('resolveOptionStates (pure)', () => {
     expect(states.get('optionC')).toMatchObject({forcedOn: true});
   });
 
-  it('terminates on circular requires', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('terminates on circular requires', () => {
     const options = {
       optionA: {requires: ['optionB']},
       optionB: {requires: ['optionA']},
@@ -218,9 +211,7 @@ describe('resolveOptionStates (pure)', () => {
     expect(states.get('optionB')).toMatchObject({forcedOn: true});
   });
 
-  it('lets forced-off win over forced-on', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('lets forced-off win over forced-on', () => {
     const options = {
       optionA: {requires: ['optionC']},
       optionB: {excludes: ['optionC']},
@@ -233,12 +224,10 @@ describe('resolveOptionStates (pure)', () => {
       entries: [entry('optionA', TriState.On), entry('optionB', TriState.On), entry('optionC', TriState.Inherit)],
     });
 
-    expect(states.get('optionC')).toMatchObject({forcedOn: false, forcedOff: true, targetValue: TriState.Off});
+    expect(states.get('optionC')).toMatchObject({forcedOn: false, forcedOff: true});
   });
 
-  it('marks options missing from availability data as unsupported and hidden', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('marks options missing from availability data as unsupported and hidden', () => {
     const options = {requiresSignature: {}} as unknown as CarrierModel['options'];
 
     const states = resolveOptionStates({
@@ -247,13 +236,11 @@ describe('resolveOptionStates (pure)', () => {
       entries: [entry('requiresSignature', TriState.Inherit), entry('hideSender', TriState.Inherit)],
     });
 
-    expect(states.get('requiresSignature')).toMatchObject({supported: true, visible: true});
-    expect(states.get('hideSender')).toMatchObject({supported: false, visible: false});
+    expect(states.get('requiresSignature')).toMatchObject({supported: true});
+    expect(states.get('hideSender')).toMatchObject({supported: false});
   });
 
-  it('produces no locks and no coercions without rule data', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('produces no locks and no coercions without rule data', () => {
     const states = resolveOptionStates({
       availabilityOptions: realOptions(),
       shipmentOptions: undefined,
@@ -261,24 +248,21 @@ describe('resolveOptionStates (pure)', () => {
     });
 
     expect(states.get('requiresSignature')).toMatchObject({forcedOn: false, forcedOff: false, readOnly: false});
-    expect(states.get('requiresSignature')?.targetValue).toBeUndefined();
   });
 
-  it('marks everything unsupported without availability data', async () => {
-    const {resolveOptionStates} = await import('./useShipmentOptionsState');
-
+  it('marks everything unsupported without availability data', () => {
     const states = resolveOptionStates({
       availabilityOptions: undefined,
       shipmentOptions: undefined,
       entries: [entry('requiresSignature', TriState.Inherit)],
     });
 
-    expect(states.get('requiresSignature')).toMatchObject({supported: false, visible: false});
+    expect(states.get('requiresSignature')).toMatchObject({supported: false});
   });
 });
 
 describe('useShipmentOptionsState (reactive)', () => {
-  const setup = async (
+  const setup = (
     initialValues: Record<string, unknown>,
     defaults: Record<string, TriState> = {},
     selectionCarrier = 'POSTNL',
@@ -295,8 +279,6 @@ describe('useShipmentOptionsState (reactive)', () => {
     }>;
 
     const scope = effectScope();
-    const {useShipmentOptionsState, getOptionState} = await import('./useShipmentOptionsState');
-
     scope.run(() => {
       useShipmentOptionsState(form as never, ALL_KEYS, {orderId: 'order-1', selection});
     });
@@ -310,7 +292,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   };
 
   it('turns dependent options on and locks them when the form opens with the source already on', async () => {
-    const {form, shipmentEntry, scope, getOptionState} = await setup({
+    const {form, shipmentEntry, scope, getOptionState} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Off,
@@ -332,7 +314,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('turns dependent options on and locks them when the source is on through its inherited default', async () => {
-    const {form, shipmentEntry, scope, getOptionState} = await setup(
+    const {form, shipmentEntry, scope, getOptionState} = setup(
       {
         [optionFieldName('requiresAgeVerification')]: TriState.Inherit,
         [optionFieldName('requiresSignature')]: TriState.Inherit,
@@ -352,7 +334,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('unlocks dependents without reverting their values when the source turns off', async () => {
-    const {form, shipmentEntry, scope, getOptionState} = await setup({
+    const {form, shipmentEntry, scope, getOptionState} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
@@ -377,7 +359,7 @@ describe('useShipmentOptionsState (reactive)', () => {
 
     (options as Record<string, {isRequired?: boolean}>).requiresSignature.isRequired = true;
 
-    const {form, shipmentEntry, scope, getOptionState} = await setup({
+    const {form, shipmentEntry, scope, getOptionState} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
@@ -398,7 +380,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('applies no locks and writes nothing while the shipment query is loading', async () => {
-    const {scope, getOptionState, form} = await setup({
+    const {scope, getOptionState, form} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
     });
@@ -412,7 +394,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('keeps existing locks while the same carrier is being refetched', async () => {
-    const {form, shipmentEntry, scope, getOptionState} = await setup({
+    const {form, shipmentEntry, scope, getOptionState} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
@@ -433,7 +415,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('drops locks when the form carrier no longer matches the fetched selection', async () => {
-    const {form, shipmentEntry, scope, getOptionState} = await setup({
+    const {form, shipmentEntry, scope, getOptionState} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,
@@ -454,7 +436,7 @@ describe('useShipmentOptionsState (reactive)', () => {
   });
 
   it('turns a forced option back on when something else switches it off', async () => {
-    const {form, shipmentEntry, scope} = await setup({
+    const {form, shipmentEntry, scope} = setup({
       [optionFieldName('requiresAgeVerification')]: TriState.On,
       [optionFieldName('requiresSignature')]: TriState.Inherit,
       [optionFieldName('recipientOnlyDelivery')]: TriState.Inherit,

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.spec.ts
@@ -104,6 +104,48 @@ const realOptions = (): CarrierModel['options'] =>
 
 const ALL_KEYS = ['requiresAgeVerification', 'requiresSignature', 'recipientOnlyDelivery', 'requiresReceiptCode'];
 
+/**
+ * Verbatim option rules from a real POSTNL proxyCapabilities response. Receipt code requires
+ * insurance while excluding signature and only recipient, and insurance requires those same two
+ * options — the data asks for and rules out the same pair. Signature and only recipient exclude
+ * receipt code in return.
+ */
+const receiptCodeOptions = (): CarrierModel['options'] =>
+  ({
+    insurance: {
+      isRequired: false,
+      isSelectedByDefault: false,
+      requires: ['requiresSignature', 'recipientOnlyDelivery'],
+      excludes: ['printReturnLabelAtDropOff'],
+    },
+    recipientOnlyDelivery: {
+      isRequired: false,
+      isSelectedByDefault: false,
+      requires: [],
+      excludes: ['printReturnLabelAtDropOff', 'requiresReceiptCode'],
+    },
+    requiresReceiptCode: {
+      isRequired: false,
+      isSelectedByDefault: false,
+      requires: ['insurance'],
+      excludes: [
+        'requiresAgeVerification',
+        'recipientOnlyDelivery',
+        'printReturnLabelAtDropOff',
+        'returnOnFirstFailedDelivery',
+        'requiresSignature',
+      ],
+    },
+    requiresSignature: {
+      isRequired: false,
+      isSelectedByDefault: false,
+      requires: [],
+      excludes: ['printReturnLabelAtDropOff', 'requiresReceiptCode'],
+    },
+  } as CarrierModel['options']);
+
+const RECEIPT_CODE_KEYS = ['requiresReceiptCode', 'requiresSignature', 'recipientOnlyDelivery', 'insurance'];
+
 const buildCarrier = (overrides: Partial<CarrierModel>): CarrierModel =>
   ({
     carrier: 'POSTNL',
@@ -211,7 +253,12 @@ describe('resolveOptionStates (pure)', () => {
     expect(states.get('optionB')).toMatchObject({forcedOn: true});
   });
 
-  it('lets forced-off win over forced-on', () => {
+  it.each([
+    [['optionA', 'optionB'], {forcedOn: true, forcedOff: false}],
+    [['optionB', 'optionA'], {forcedOn: false, forcedOff: true}],
+  ])('applies whichever rule comes first when two enabled options disagree, read as %j', (order, expected) => {
+    // Option A requires option C, and option B excludes option C. The two kinds of rule have equal
+    // rank. The option that the resolver reads first has effect, and it reports the other rule.
     const options = {
       optionA: {requires: ['optionC']},
       optionB: {excludes: ['optionC']},
@@ -221,10 +268,91 @@ describe('resolveOptionStates (pure)', () => {
     const states = resolveOptionStates({
       availabilityOptions: options,
       shipmentOptions: options,
-      entries: [entry('optionA', TriState.On), entry('optionB', TriState.On), entry('optionC', TriState.Inherit)],
+      entries: [...order.map((key) => entry(key, TriState.On)), entry('optionC', TriState.Inherit)],
     });
 
-    expect(states.get('optionC')).toMatchObject({forcedOn: false, forcedOff: true});
+    expect(states.get('optionC')).toMatchObject(expected);
+    expect(states.get('optionC')?.readOnly).toBe(true);
+  });
+
+  it('forces off what an enabled option excludes, even when a requires chain asks for them', () => {
+    const states = resolveOptionStates({
+      availabilityOptions: receiptCodeOptions(),
+      shipmentOptions: receiptCodeOptions(),
+      entries: [
+        entry('requiresReceiptCode', TriState.Inherit, TriState.On),
+        entry('requiresSignature', TriState.Off),
+        entry('recipientOnlyDelivery', TriState.Off),
+        entry('insurance', TriState.Off),
+      ],
+    });
+
+    // Receipt code excludes the two options. The requires chain through insurance must not set
+    // them to on.
+    expect(states.get('requiresSignature')).toMatchObject({forcedOn: false, forcedOff: true, readOnly: true});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOn: false, forcedOff: true, readOnly: true});
+
+    // What receipt code does require is still forced on.
+    expect(states.get('insurance')).toMatchObject({forcedOn: true});
+
+    // The merchant's own option keeps its value and stays editable.
+    expect(states.get('requiresReceiptCode')).toMatchObject({forcedOn: false, forcedOff: false, readOnly: false});
+  });
+
+  it('settles immediately: applying the forced values produces the same states again', () => {
+    const entries = [
+      entry('requiresReceiptCode', TriState.Inherit, TriState.On),
+      entry('requiresSignature', TriState.Off),
+      entry('recipientOnlyDelivery', TriState.Off),
+      entry('insurance', TriState.Off),
+    ];
+
+    const forcedFlags = (states: Map<string, {forcedOn: boolean; forcedOff: boolean}>) =>
+      [...states].map(([key, state]) => [key, state.forcedOn, state.forcedOff]);
+
+    const resolve = () =>
+      resolveOptionStates({
+        availabilityOptions: receiptCodeOptions(),
+        shipmentOptions: receiptCodeOptions(),
+        entries,
+      });
+
+    const first = resolve();
+
+    // Do the same as applyForcedValues. Write each forced value, but do not change an option that
+    // is not a toggle.
+    entries.forEach((current) => {
+      const state = first.get(current.key);
+
+      if (current.key === 'insurance' || !state || (!state.forcedOn && !state.forcedOff)) {
+        return;
+      }
+
+      current.value = state.forcedOn ? TriState.On : TriState.Off;
+    });
+
+    // A write to insurance makes insurance an enabled option. Its requires rules then set the
+    // options that receipt code excludes, and the next pass locks receipt code to off.
+    expect(forcedFlags(resolve())).toEqual(forcedFlags(first));
+  });
+
+  it('drops every conflicting option when an order was stored with a combination the rules forbid', () => {
+    // An order from an earlier version can hold all three options at the same time. No rule can
+    // satisfy this data, and thus the resolver sets the three options to off.
+    const states = resolveOptionStates({
+      availabilityOptions: receiptCodeOptions(),
+      shipmentOptions: receiptCodeOptions(),
+      entries: [
+        entry('requiresReceiptCode', TriState.On),
+        entry('requiresSignature', TriState.On),
+        entry('recipientOnlyDelivery', TriState.On),
+        entry('insurance', TriState.Off),
+      ],
+    });
+
+    expect(states.get('requiresSignature')).toMatchObject({forcedOff: true});
+    expect(states.get('recipientOnlyDelivery')).toMatchObject({forcedOff: true});
+    expect(states.get('requiresReceiptCode')).toMatchObject({forcedOff: true});
   });
 
   it('marks options missing from availability data as unsupported and hidden', () => {
@@ -266,6 +394,7 @@ describe('useShipmentOptionsState (reactive)', () => {
     initialValues: Record<string, unknown>,
     defaults: Record<string, TriState> = {},
     selectionCarrier = 'POSTNL',
+    keys: string[] = ALL_KEYS,
   ) => {
     const form = buildForm({[FIELD_CARRIER]: 'POSTNL', ...initialValues}, defaults);
 
@@ -280,7 +409,7 @@ describe('useShipmentOptionsState (reactive)', () => {
 
     const scope = effectScope();
     scope.run(() => {
-      useShipmentOptionsState(form as never, ALL_KEYS, {orderId: 'order-1', selection});
+      useShipmentOptionsState(form as never, keys, {orderId: 'order-1', selection});
     });
 
     return {form, shipmentEntry, selection, scope, getOptionState};
@@ -309,6 +438,77 @@ describe('useShipmentOptionsState (reactive)', () => {
     expect(getOptionState(form as never, 'recipientOnlyDelivery').readOnly).toBe(true);
     expect(getOptionState(form as never, 'requiresReceiptCode').readOnly).toBe(true);
     expect(getOptionState(form as never, 'requiresAgeVerification').readOnly).toBe(false);
+
+    scope.stop();
+  });
+
+  it('keeps the amount of a required option that holds a range', async () => {
+    const insuranceField = optionFieldName('insurance');
+
+    const {form, shipmentEntry, scope} = setup(
+      {
+        [optionFieldName('requiresReceiptCode')]: TriState.Inherit,
+        [optionFieldName('requiresSignature')]: TriState.Off,
+        [optionFieldName('recipientOnlyDelivery')]: TriState.Off,
+        // An amount in cents, not a tri-state.
+        [insuranceField]: 25_000,
+      },
+      {[optionFieldName('requiresReceiptCode')]: TriState.On},
+      'POSTNL',
+      RECEIPT_CODE_KEYS,
+    );
+
+    resolveShipment(shipmentEntry, receiptCodeOptions());
+    await nextTick();
+
+    // Receipt code requires insurance. A requires rule gives a range of amounts, and thus the
+    // field keeps its amount. Export applies the rule again.
+    expect(form.state[insuranceField]).toBe(25_000);
+    expect(setFieldRefMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({name: insuranceField}),
+      expect.anything(),
+    );
+
+    // Receipt code stays on, and the two options it excludes are off and locked.
+    expect(form.state[optionFieldName('requiresSignature')]).toBe(TriState.Off);
+    expect(form.state[optionFieldName('recipientOnlyDelivery')]).toBe(TriState.Off);
+    expect(form.state[optionFieldName('requiresReceiptCode')]).toBe(TriState.Inherit);
+    expect(getOptionState(form as never, 'requiresReceiptCode').readOnly).toBe(false);
+
+    scope.stop();
+  });
+
+  it('clears the amount of an excluded option that holds a range', async () => {
+    const insuranceField = optionFieldName('insurance');
+
+    const options = {
+      requiresSignature: {isRequired: false, requires: [], excludes: ['insurance']},
+      insurance: {isRequired: false, requires: ['recipientOnlyDelivery'], excludes: []},
+      recipientOnlyDelivery: {isRequired: false, requires: [], excludes: []},
+    } as unknown as CarrierModel['options'];
+
+    const {form, shipmentEntry, scope} = setup(
+      {
+        [optionFieldName('requiresSignature')]: TriState.On,
+        [optionFieldName('recipientOnlyDelivery')]: TriState.Off,
+        [insuranceField]: 25_000,
+      },
+      {},
+      'POSTNL',
+      ['requiresSignature', 'recipientOnlyDelivery', 'insurance'],
+    );
+
+    resolveShipment(shipmentEntry, options);
+    await nextTick();
+
+    // An excludes rule gives one value. The resolver clears the old amount and does not lock the
+    // field on that amount.
+    expect(form.state[insuranceField]).toBe(TriState.Off);
+
+    // An amount of off is not an enabled option. Insurance therefore cannot set only recipient
+    // to on.
+    expect(form.state[optionFieldName('recipientOnlyDelivery')]).toBe(TriState.Off);
+    expect(getOptionState(form as never, 'recipientOnlyDelivery').forcedOn).toBe(false);
 
     scope.stop();
   });

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
@@ -1,4 +1,4 @@
-import {reactive, ref, watch, type Ref} from 'vue';
+import {getCurrentScope, onScopeDispose, reactive, ref, watch, type Ref} from 'vue';
 import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
 import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
 import {triStateValueIsEnabled, useFormCapabilities} from '../helpers';
@@ -212,6 +212,18 @@ export const useShipmentOptionsState = (
   const states = ref(new Map<string, OptionState>());
 
   formStates.set(form.name, states.value);
+
+  // Drop the entry when the form's scope disposes (e.g. modal close), like wireProxyCapabilities
+  // does for its queries. Only when the registry still holds OUR states: a reopened modal may
+  // have re-registered under the same form name before the old scope is disposed. Guarded
+  // because unit tests may call this outside a scope.
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (formStates.get(form.name) === states.value) {
+        formStates.delete(form.name);
+      }
+    });
+  }
 
   watch(
     () => ({

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
@@ -1,4 +1,4 @@
-import {ref, watch, type Ref} from 'vue';
+import {reactive, ref, watch, type Ref} from 'vue';
 import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
 import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
 import {triStateValueIsEnabled, useFormCapabilities} from '../helpers';
@@ -9,11 +9,8 @@ import {readShipmentSnapshot} from './readShipmentSnapshot';
 import {FIELD_CARRIER, optionFieldName} from './field';
 
 /**
- * THE single point of reference for shipment-option field state. Every rule that decides an
- * option's availability, lock state or forced value lives in {@link resolveOptionStates};
- * everything else only reads the result.
- *
- * Information flow:
+ * The single point of reference for shipment-option field state: every rule deciding an
+ * option's availability, lock state or forced value lives in {@link resolveOptionStates}.
  *
  *     proxy-capabilities queries ──▶ readShipmentSnapshot (pending / invalid / matched)
  *     form option values ──────────┐
@@ -24,22 +21,8 @@ import {FIELD_CARRIER, optionFieldName} from './field';
  *                       {supported, readOnly, forcedOn, forcedOff}
  *                          │                             │
  *              field hooks read flags          one watcher writes the forced
- *              (visibleWhen/disabledWhen/      values into the fields (locked with
- *               readOnlyWhen = one lookup)      readOnly, not disabled, so they submit)
- *
- * Why this shape (not a data-returning composable): the state is read by field hook closures
- * (`visibleWhen` / `readOnlyWhen` / `disabledWhen`) that vue-form-builder invokes outside Vue
- * setup context, with only the form instance available. They cannot receive a composable's
- * return value or call inject(), so the composable registers the state per form (WeakMap) and
- * the hooks look it up through {@link getOptionState}. Same approach, and same reason, as
- * `useFormCapabilities`.
- *
- * @TODO: fold useCapabilitiesAutoClear's option-reset (clearing active options the carrier no
- *        longer supports) into resolveOptionStates as well — including one shared, silent
- *        field-write path for both modules — so option-state truly has a single module.
- * @TODO: non-toggle options (insurance, an int amount) are never treated as enabled here, so
- *        their requires/excludes rules are not applied yet; scope per-option kinds when that
- *        becomes relevant (the DO widget defers the same case).
+ *              (visibleWhen/disabledWhen/       values into the fields
+ *               readOnlyWhen = one lookup)
  */
 
 export type OptionState = {
@@ -68,11 +51,8 @@ export type ResolveOptionStatesInput = {
    */
   availabilityOptions: CarrierModel['options'] | undefined;
   /**
-   * The chosen carrier's options from a *matched* shipment-scoped capabilities response —
-   * the single source of `isRequired` / `requires` / `excludes`. Not to be confused with the
-   * order's `deliveryOptions.shipmentOptions` values; those come in through `entries`.
-   * Undefined while loading or invalid: nothing is locked or forced then, because the rule
-   * data doesn't exist in any other response.
+   * The chosen carrier's options from a *matched* shipment-scoped capabilities response — the
+   * only source of `isRequired` / `requires` / `excludes`. Undefined while loading or invalid.
    */
   shipmentOptions: CarrierModel['options'] | undefined;
   entries: OptionStateEntry[];
@@ -83,20 +63,10 @@ export type ResolveOptionStatesInput = {
  * ------------------------------------------------------------------------------------------- */
 
 /**
- * Compute the complete state of every shipment option. Pure — all inputs in, one map out.
+ * Compute the complete state of every shipment option. Pure — all inputs in, one map out. The
+ * forcing rules mirror the server-side CapabilitiesOptionCalculator.
  *
- * Forcing rules, mirroring the server-side CapabilitiesOptionCalculator:
- * - carrier-required options (`isRequired`) are forced on, including everything their
- *   `requires` lists point to, directly or indirectly;
- * - enabled options pull in everything their `requires` lists point to (the option itself
- *   stays free — its own value is the user's choice);
- * - `excludes` of every active option force the excluded options off;
- * - on conflict, forced-off wins (the PHP calculator depends on iteration order here; real
- *   data has no conflicting rules).
- *
- * @param input - See {@link ResolveOptionStatesInput}: the option map used for availability,
- *   the option map used for rules (only from a matched shipment response), and one entry per
- *   option field with its current form value and inherited default.
+ * @param input - See {@link ResolveOptionStatesInput}; one `entries` item per option field.
  */
 export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string, OptionState> => {
   const {availabilityOptions, shipmentOptions, entries} = input;
@@ -105,6 +75,9 @@ export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string
   let forcedOff = new Set<string>();
 
   if (shipmentOptions) {
+    // Options that are on: explicitly, or through their inherited default.
+    // @TODO: non-toggle options (insurance, an int amount) are never treated as enabled here,
+    //        so their requires/excludes are not applied yet (the DO widget defers the same case).
     const enabledKeys = entries
       .filter((entry) => triStateValueIsEnabled(entry.value, entry.defaultValue))
       .map((entry) => entry.key);
@@ -112,6 +85,7 @@ export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string
     forcedOn = resolveForcedOn(shipmentOptions, enabledKeys);
     forcedOff = resolveForcedOff(shipmentOptions, new Set([...enabledKeys, ...forcedOn]));
 
+    // On conflict, forced-off wins -- normally data should have no conflicting rules.
     for (const key of forcedOff) {
       forcedOn.delete(key);
     }
@@ -135,22 +109,19 @@ export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string
 };
 
 /**
- * Collect every option that must be turned on. Starting from the carrier-required options and
- * the enabled options, follow each option's `requires` list — and the `requires` of those
- * options in turn, until no new options show up (options that were already seen are skipped,
- * so circular requires can't loop forever). Carrier-required options are included in the
- * result themselves; enabled options are not — their own value is the user's choice.
+ * Collect every option that must be turned on, following `requires` lists transitively.
  *
- * @param shipmentOptions - The option map from the matched shipment-scoped capabilities
- *   response, keyed by capability option key (e.g. `requiresSignature`). Each entry may carry
- *   `isRequired`, `requires` and `excludes`.
- * @param enabledKeys - Capability option keys of the options that are currently on in the
- *   form (explicitly, or through their inherited default).
+ * @param shipmentOptions - The option map from the matched shipment-scoped response.
+ * @param enabledKeys - Capability option keys of the options that are currently on.
  */
 const resolveForcedOn = (shipmentOptions: NonNullable<CarrierModel['options']>, enabledKeys: string[]): Set<string> => {
   const requiredKeys = Object.keys(shipmentOptions).filter((key) => shipmentOptions[key]?.isRequired === true);
+
+  // Carrier-required options force themselves; enabled options only force what they require —
+  // their own value stays the user's choice.
   const forcedOn = new Set(requiredKeys);
 
+  // `visited` skips options that were already walked, so circular requires can't loop forever.
   const queue = [...requiredKeys, ...enabledKeys];
   const visited = new Set(queue);
 
@@ -171,11 +142,7 @@ const resolveForcedOn = (shipmentOptions: NonNullable<CarrierModel['options']>, 
 };
 
 /**
- * Collect the `excludes` of every active option into the forced-off set.
- *
- * @param shipmentOptions - The option map from the matched shipment-scoped capabilities response.
- * @param activeKeys - Every option that is on: the enabled options plus the forced-on set
- *   computed by {@link resolveForcedOn}.
+ * Collect the `excludes` of every active option (enabled plus forced-on) into the forced-off set.
  */
 const resolveForcedOff = (
   shipmentOptions: NonNullable<CarrierModel['options']>,
@@ -205,7 +172,10 @@ type ShipmentQueryContext = {
   selection: Readonly<Ref<CapabilitiesSelection>>;
 };
 
-const formStates = new WeakMap<FormInstance, Ref<Map<string, OptionState>>>();
+// Registry the field hooks read through getOptionState — they run outside Vue setup context
+// (no inject), with only the form available.
+// A reactive Map keyed by form name, it MUST be reactive to allow Vue to respond to new or changed form states.
+const formStates = reactive(new Map<string, Map<string, OptionState>>());
 
 /** State for options we know nothing about: visible and editable, nothing locked or forced. */
 const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
@@ -216,19 +186,7 @@ const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
 });
 
 /**
- * Connect the option-state resolver to a shipment-options form. States are recomputed when
- * the shipment capabilities response, any option value, an inherited default, or the chosen
- * carrier changes. Forced values are written into the fields; locked fields use readOnly, not
- * disabled, so their values are still submitted and end up stored on the order.
- *
- * Without a shipment query (bulk forms, orders without an identifier) the module still
- * resolves which options are available, but never locks or forces anything — the
- * requires/excludes rule data only exists on the shipment-scoped response.
- *
- * While a reload for the same carrier is in progress, the previous states are kept on purpose:
- * recomputing without rule data would briefly unlock every forced option until the response
- * arrives. After a carrier switch the previous locks are dropped immediately instead, because
- * they belong to the old carrier's rules.
+ * Connect the option-state resolver to a shipment-options form.
  *
  * @param form - The shipment-options form to resolve states for; must contain the option
  *   fields (`deliveryOptions.shipmentOptions.<key>`) and the carrier field.
@@ -237,7 +195,11 @@ const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
  * @param shipmentQuery - Where to find the per-order shipment capabilities query: the order's
  *   external identifier (the query-store key) and the debounced selection returned by
  *   `wireProxyCapabilities`. Leave out for bulk forms and orders without an identifier —
- *   options then resolve availability only and are never locked or forced.
+ *   options then resolve availability only and are never locked or forced (requires/excludes
+ *   rule data only exists on the shipment-scoped response).
+ *
+ * @TODO: fold useCapabilitiesAutoClear's option-reset (clearing active options the carrier no
+ *        longer supports) in as well, so option-state truly has a single module.
  */
 export const useShipmentOptionsState = (
   form: FormInstance,
@@ -249,7 +211,7 @@ export const useShipmentOptionsState = (
 
   const states = ref(new Map<string, OptionState>());
 
-  formStates.set(form, states);
+  formStates.set(form.name, states.value);
 
   watch(
     () => ({
@@ -258,15 +220,15 @@ export const useShipmentOptionsState = (
         : undefined,
       // The shipment response only applies while the form still shows the carrier it was
       // fetched for; right after a carrier switch the (debounced) query still holds the old
-      // carrier's data.
+      // carrier's data — the old carrier's locks are dropped immediately.
       selectionMatchesForm:
         Boolean(shipmentQuery) && form.getValue(FIELD_CARRIER) === shipmentQuery?.selection.value.carrier,
       availabilityOptions: capabilities.getCarrierCapabilitiesForShipment(form)?.options,
       entries: readEntries(form, allOptionKeys),
     }),
     ({snapshot, selectionMatchesForm, availabilityOptions, entries}) => {
-      // A reload for the same carrier (e.g. after a weight change): keep the current locks
-      // until the new response arrives, instead of unlocking everything in the meantime.
+      // A reload for the same carrier (e.g. after a weight change): keep the current locks —
+      // recomputing without rule data would briefly unlock every forced option.
       if (snapshot?.state === 'pending' && selectionMatchesForm && states.value.size > 0) {
         return;
       }
@@ -277,6 +239,7 @@ export const useShipmentOptionsState = (
       const next = resolveOptionStates({availabilityOptions, shipmentOptions, entries});
 
       states.value = next;
+      formStates.set(form.name, next);
       applyForcedValues(form, next);
     },
     {immediate: true},
@@ -284,30 +247,21 @@ export const useShipmentOptionsState = (
 };
 
 /**
- * Read a single option's resolved state. Field hooks (`visibleWhen` / `disabledWhen` /
- * `readOnlyWhen`) call this — reading `states.value` inside those reactive re-evaluators
- * makes them re-run whenever the states are recomputed. Forms that never registered with
- * {@link useShipmentOptionsState} (e.g. field-factory unit tests) get a neutral state that
- * leaves the field visible and editable.
+ * Read a single option's resolved state; the field hooks (`visibleWhen` / `disabledWhen` /
+ * `readOnlyWhen`) are one call to this each.
  *
  * @param form - The shipment-options form the option field belongs to.
  * @param optionKey - The capability option key: the part after the last dot of the field
  *   name (`requiresSignature` for the field `deliveryOptions.shipmentOptions.requiresSignature`).
  */
 export const getOptionState = (form: FormInstance, optionKey: string): OptionState => {
-  const states = formStates.get(form);
+  const states = formStates.get(form.name);
 
-  if (!states) return NEUTRAL_OPTION_STATE;
-
-  return states.value.get(optionKey) ?? NEUTRAL_OPTION_STATE;
+  // Forms that never registered (e.g. field-factory unit tests) stay visible and editable.
+  return states?.get(optionKey) ?? NEUTRAL_OPTION_STATE;
 };
 
-/**
- * Read the current form value and inherited default of every option field.
- *
- * @param form - The shipment-options form holding the option fields.
- * @param allOptionKeys - Every capability option key a field was created for.
- */
+/** Read the current form value and inherited default of every option field. */
 const readEntries = (form: FormInstance, allOptionKeys: string[]): OptionStateEntry[] =>
   allOptionKeys.map((key) => {
     const fieldName = optionFieldName(key);
@@ -322,13 +276,8 @@ const readEntries = (form: FormInstance, allOptionKeys: string[]): OptionStateEn
 
 /**
  * Write the forced value (on for forced-on, off for forced-off) into every affected field.
- * Fields that already hold the value are skipped — the watcher runs again after each write,
- * and because unchanged values are skipped it stops by itself once every forced value is in
- * place.
- *
- * @param form - The form whose option fields receive the forced values.
- * @param states - The resolved states from {@link resolveOptionStates}, keyed by capability
- *   option key.
+ * Forced fields are locked with readOnly, not disabled, so their values still submit and
+ * end up stored on the order.
  */
 const applyForcedValues = (form: FormInstance, states: Map<string, OptionState>): void => {
   for (const [key, state] of states) {
@@ -338,6 +287,8 @@ const applyForcedValues = (form: FormInstance, states: Map<string, OptionState>)
     const fieldName = optionFieldName(key);
     const field = form.getField(fieldName);
 
+    // Skipping fields that already hold the value makes the write-then-recompute cycle stop
+    // by itself once every forced value is in place.
     if (!field || form.getValue(fieldName) === forcedValue) continue;
 
     setFieldRef(field as InteractiveElementInstance, forcedValue);

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
@@ -1,0 +1,369 @@
+import {ref, watch, type Ref} from 'vue';
+import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
+import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
+import {useFormCapabilities} from '../helpers';
+import {setFieldRef} from '../form-builder/utils/createValueSetter';
+import {useQueryStore} from '../../stores';
+import {type CapabilitiesSelection} from './wireProxyCapabilities';
+import {readShipmentSnapshot} from './readShipmentSnapshot';
+import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
+
+/**
+ * THE single point of reference for shipment-option field state. Every rule that decides an
+ * option's availability, lock state or forced value lives in {@link resolveOptionStates};
+ * everything else only reads the result.
+ *
+ * Information flow:
+ *
+ *     proxy-capabilities queries ──▶ readShipmentSnapshot (pending / invalid / matched)
+ *     form option values ──────────┐
+ *     inherited defaults ──────────┤──▶ resolveOptionStates() [PURE — every rule lives here]
+ *     carrier capability options ──┘         │
+ *                                            ▼
+ *                            Map<optionKey, OptionState>
+ *                 {supported, visible, readOnly, forcedOn, forcedOff, targetValue}
+ *                          │                             │
+ *              field hooks read flags          one watcher writes targetValue
+ *              (visibleWhen/disabledWhen/      into the fields (locked with readOnly,
+ *               readOnlyWhen = one lookup)      not disabled, so values still submit)
+ *
+ * Why this shape (not a data-returning composable): the state is read by field hook closures
+ * (`visibleWhen` / `readOnlyWhen` / `disabledWhen`) that vue-form-builder invokes outside Vue
+ * setup context, with only the form instance available. They cannot receive a composable's
+ * return value or call inject(), so the composable registers the state per form (WeakMap) and
+ * the hooks look it up through {@link getOptionState}. Same approach, and same reason, as
+ * `useFormCapabilities`.
+ *
+ * @TODO: fold useCapabilitiesAutoClear's option-reset (clearing active options the carrier no
+ *        longer supports) into resolveOptionStates as well, so option-state truly has a single
+ *        module.
+ */
+
+export type OptionState = {
+  /** The current capability data contains this option at all. */
+  supported: boolean;
+  /** The field is rendered (currently equal to `supported`). */
+  visible: boolean;
+  /** The field is locked: carrier-required, or forced on/off by another enabled option. */
+  readOnly: boolean;
+  /** Forced on through a requires relation or carrier isRequired. */
+  forcedOn: boolean;
+  /** Forced off through an excludes relation. */
+  forcedOff: boolean;
+  /** The value the field must hold; written through by the composable so it persists. */
+  targetValue?: TriState;
+};
+
+export type OptionStateEntry = {
+  key: string;
+  /** Raw tri-state form value. */
+  value: TriState | undefined;
+  /** Inherited default shown for `Inherit` (maintained by updateFieldsDefaults). */
+  defaultValue: TriState | undefined;
+};
+
+export type ResolveOptionStatesInput = {
+  /**
+   * Options from the regular fallback chain (shipment query → order query → dynamic context).
+   * Decides which options exist for the current carrier — i.e. `supported` / `visible`.
+   */
+  availabilityOptions: CarrierModel['options'] | undefined;
+  /**
+   * The chosen carrier's options from a *matched* shipment-scoped capabilities response —
+   * the single source of `isRequired` / `requires` / `excludes`. Not to be confused with the
+   * order's `deliveryOptions.shipmentOptions` values; those come in through `entries`.
+   * Undefined while loading or invalid: nothing is locked or forced then, because the rule
+   * data doesn't exist in any other response.
+   */
+  shipmentOptions: CarrierModel['options'] | undefined;
+  entries: OptionStateEntry[];
+};
+
+/** State for options we know nothing about: visible and editable, nothing locked or forced. */
+const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
+  supported: true,
+  visible: true,
+  readOnly: false,
+  forcedOn: false,
+  forcedOff: false,
+});
+
+/**
+ * An option counts as enabled when it's explicitly on, or inheriting while its inherited
+ * default is on — the same interpretation `triStateFieldIsEnabled` applies elsewhere.
+ */
+const isEffectivelyEnabled = (entry: OptionStateEntry): boolean =>
+  TriState.On === entry.value || (TriState.Inherit === entry.value && TriState.On === entry.defaultValue);
+
+/**
+ * Collect every option that must be turned on. Starting from the carrier-required options and
+ * the enabled options, follow each option's `requires` list — and the `requires` of those
+ * options in turn, until no new options show up (options that were already seen are skipped,
+ * so circular requires can't loop forever). Carrier-required options are included in the
+ * result themselves; enabled options are not — their own value is the user's choice.
+ *
+ * @param shipmentOptions - The option map from the matched shipment-scoped capabilities response,
+ *   keyed by capability option key (e.g. `requiresSignature`). Each entry may carry
+ *   `isRequired`, `requires` and `excludes`.
+ * @param enabledKeys - Capability option keys of the options that are currently on in the
+ *   form (explicitly, or through their inherited default).
+ */
+const resolveForcedOn = (shipmentOptions: NonNullable<CarrierModel['options']>, enabledKeys: string[]): Set<string> => {
+  const forcedOn = new Set<string>();
+  const requiredKeys = Object.keys(shipmentOptions).filter((key) => shipmentOptions[key]?.isRequired === true);
+
+  requiredKeys.forEach((key) => forcedOn.add(key));
+
+  const queue = [...requiredKeys, ...enabledKeys];
+  const visited = new Set(queue);
+
+  while (queue.length > 0) {
+    const key = queue.shift() as string;
+
+    for (const required of shipmentOptions[key]?.requires ?? []) {
+      forcedOn.add(required);
+
+      if (!visited.has(required)) {
+        visited.add(required);
+        queue.push(required);
+      }
+    }
+  }
+
+  return forcedOn;
+};
+
+/**
+ * Collect the `excludes` of every active option into the forced-off set.
+ *
+ * @param shipmentOptions - The option map from the matched shipment-scoped capabilities response.
+ * @param activeKeys - Every option that is on: the enabled options plus the forced-on set
+ *   computed by {@link resolveForcedOn}.
+ */
+const resolveForcedOff = (
+  shipmentOptions: NonNullable<CarrierModel['options']>,
+  activeKeys: Set<string>,
+): Set<string> => {
+  const forcedOff = new Set<string>();
+
+  for (const key of activeKeys) {
+    for (const excluded of shipmentOptions[key]?.excludes ?? []) {
+      forcedOff.add(excluded);
+    }
+  }
+
+  return forcedOff;
+};
+
+/**
+ * Decide which value a field must be set to, if any. Returns undefined when the field may
+ * keep its current value.
+ *
+ * @param entry - The option's key plus its current form value and inherited default.
+ * @param isForcedOn - Whether the option is in the forced-on set.
+ * @param isForcedOff - Whether the option is in the forced-off set.
+ */
+const resolveTargetValue = (
+  entry: OptionStateEntry,
+  isForcedOn: boolean,
+  isForcedOff: boolean,
+): TriState | undefined => {
+  if (isForcedOn && TriState.On !== entry.value) return TriState.On;
+
+  if (isForcedOff && TriState.Off !== entry.value) return TriState.Off;
+
+  return undefined;
+};
+
+/**
+ * Compute the complete state of every shipment option. Pure — all inputs in, one map out.
+ *
+ * Forcing rules, mirroring the server-side CapabilitiesOptionCalculator:
+ * - carrier-required options (`isRequired`) are forced on, including everything their
+ *   `requires` lists point to, directly or indirectly;
+ * - enabled options pull in everything their `requires` lists point to (the option itself
+ *   stays free — its own value is the user's choice);
+ * - `excludes` of every active option force the excluded options off;
+ * - on conflict, forced-off wins (the PHP calculator depends on iteration order here; real
+ *   data has no conflicting rules).
+ *
+ * @param input - See {@link ResolveOptionStatesInput}: the option map used for availability,
+ *   the option map used for rules (only from a matched shipment response), and one entry per
+ *   option field with its current form value and inherited default.
+ */
+export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string, OptionState> => {
+  const {availabilityOptions, shipmentOptions, entries} = input;
+
+  let forcedOn = new Set<string>();
+  let forcedOff = new Set<string>();
+
+  if (shipmentOptions) {
+    const enabledKeys = entries.filter(isEffectivelyEnabled).map((entry) => entry.key);
+
+    forcedOn = resolveForcedOn(shipmentOptions, enabledKeys);
+    forcedOff = resolveForcedOff(shipmentOptions, new Set([...enabledKeys, ...forcedOn]));
+
+    for (const key of forcedOff) {
+      forcedOn.delete(key);
+    }
+  }
+
+  const states = new Map<string, OptionState>();
+
+  for (const entry of entries) {
+    const supported = Object.hasOwn(availabilityOptions ?? {}, entry.key);
+    const isForcedOn = forcedOn.has(entry.key);
+    const isForcedOff = forcedOff.has(entry.key);
+
+    states.set(entry.key, {
+      supported,
+      visible: supported,
+      readOnly: isForcedOn || isForcedOff,
+      forcedOn: isForcedOn,
+      forcedOff: isForcedOff,
+      targetValue: resolveTargetValue(entry, isForcedOn, isForcedOff),
+    });
+  }
+
+  return states;
+};
+
+/**
+ * Identifies the per-order shipment capabilities query: the order id it is registered under
+ * in the query store, and the (debounced) selection it was last fetched for.
+ */
+type ShipmentQueryContext = {
+  orderId: string;
+  selection: Readonly<Ref<CapabilitiesSelection>>;
+};
+
+const formStates = new WeakMap<FormInstance, Ref<Map<string, OptionState>>>();
+
+const optionFieldName = (key: string): string => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
+
+/**
+ * Read a single option's resolved state. Field hooks (`visibleWhen` / `disabledWhen` /
+ * `readOnlyWhen`) call this — reading `states.value` inside those reactive re-evaluators
+ * makes them re-run whenever the states are recomputed. Forms that never registered with
+ * {@link useShipmentOptionsState} (e.g. field-factory unit tests) get a neutral state that
+ * leaves the field visible and editable.
+ *
+ * @param form - The shipment-options form the option field belongs to.
+ * @param optionKey - The capability option key: the part after the last dot of the field
+ *   name (`requiresSignature` for the field `deliveryOptions.shipmentOptions.requiresSignature`).
+ */
+export const getOptionState = (form: FormInstance, optionKey: string): OptionState => {
+  const states = formStates.get(form);
+
+  if (!states) return NEUTRAL_OPTION_STATE;
+
+  return states.value.get(optionKey) ?? NEUTRAL_OPTION_STATE;
+};
+
+/**
+ * Connect the option-state resolver to a shipment-options form. States are recomputed when
+ * the shipment capabilities response, any option value, an inherited default, or the chosen
+ * carrier changes. Forced values are written into the fields; locked fields use readOnly, not
+ * disabled, so their values are still submitted and end up stored on the order.
+ *
+ * Without a shipment query (bulk forms, orders without an identifier) the module still
+ * resolves which options are available, but never locks or forces anything — the
+ * requires/excludes rule data only exists on the shipment-scoped response.
+ *
+ * While a reload for the same carrier is in progress, the previous states are kept on purpose:
+ * recomputing without rule data would briefly unlock every forced option until the response
+ * arrives. After a carrier switch the previous locks are dropped immediately instead, because
+ * they belong to the old carrier's rules.
+ *
+ * @param form - The shipment-options form to resolve states for; must contain the option
+ *   fields (`deliveryOptions.shipmentOptions.<key>`) and the carrier field.
+ * @param allOptionKeys - Every capability option key a field was created for: the union of
+ *   option keys across all carriers in the dynamic context, not just the current carrier's.
+ * @param shipmentQuery - Where to find the per-order shipment capabilities query: the order's
+ *   external identifier (the query-store key) and the debounced selection returned by
+ *   `wireProxyCapabilities`. Leave out for bulk forms and orders without an identifier —
+ *   options then resolve availability only and are never locked or forced.
+ */
+export const useShipmentOptionsState = (
+  form: FormInstance,
+  allOptionKeys: string[],
+  shipmentQuery?: ShipmentQueryContext,
+): void => {
+  const queryStore = useQueryStore();
+  const capabilities = useFormCapabilities();
+
+  const states = ref(new Map<string, OptionState>());
+
+  formStates.set(form, states);
+
+  watch(
+    () => ({
+      snapshot: shipmentQuery
+        ? readShipmentSnapshot(shipmentQuery.selection, queryStore, shipmentQuery.orderId)
+        : undefined,
+      availabilityOptions: capabilities.getCarrierCapabilitiesForShipment(form)?.options,
+      entries: readEntries(form, allOptionKeys),
+      carrier: form.getValue(FIELD_CARRIER) as string | undefined,
+    }),
+    ({snapshot, availabilityOptions, entries, carrier}) => {
+      // The response only applies when the form still shows the carrier it was fetched for;
+      // right after a carrier switch the (debounced) query still holds the old carrier's data.
+      const selectionMatchesForm = Boolean(shipmentQuery) && carrier === shipmentQuery?.selection.value.carrier;
+
+      // A reload for the same carrier (e.g. after a weight change): keep the current locks
+      // until the new response arrives, instead of unlocking everything in the meantime.
+      if (snapshot?.state === 'pending' && selectionMatchesForm && states.value.size > 0) {
+        return;
+      }
+
+      const shipmentOptions =
+        snapshot?.state === 'matched' && selectionMatchesForm ? snapshot.carrier.options : undefined;
+
+      const next = resolveOptionStates({availabilityOptions, shipmentOptions, entries});
+
+      states.value = next;
+      applyTargetValues(form, next);
+    },
+    {immediate: true},
+  );
+};
+
+/**
+ * Read the current form value and inherited default of every option field.
+ *
+ * @param form - The shipment-options form holding the option fields.
+ * @param allOptionKeys - Every capability option key a field was created for.
+ */
+const readEntries = (form: FormInstance, allOptionKeys: string[]): OptionStateEntry[] =>
+  allOptionKeys.map((key) => {
+    const fieldName = optionFieldName(key);
+    const field = form.getField(fieldName) as {props?: {defaultValue?: TriState}} | undefined;
+
+    return {
+      key,
+      value: form.getValue(fieldName) as TriState | undefined,
+      defaultValue: field?.props?.defaultValue,
+    };
+  });
+
+/**
+ * Write every resolved `targetValue` into its field. Fields that already hold the value are
+ * skipped — the watcher runs again after each write, and because unchanged values are skipped
+ * it stops by itself once every forced value is in place.
+ *
+ * @param form - The form whose option fields receive the forced values.
+ * @param states - The resolved states from {@link resolveOptionStates}, keyed by capability
+ *   option key.
+ */
+const applyTargetValues = (form: FormInstance, states: Map<string, OptionState>): void => {
+  for (const [key, state] of states) {
+    if (state.targetValue === undefined) continue;
+
+    const fieldName = optionFieldName(key);
+    const field = form.getField(fieldName);
+
+    if (!field || form.getValue(fieldName) === state.targetValue) continue;
+
+    setFieldRef(field as InteractiveElementInstance, state.targetValue);
+  }
+};

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
@@ -1,12 +1,12 @@
 import {ref, watch, type Ref} from 'vue';
 import {type FormInstance, type InteractiveElementInstance} from '@myparcel-dev/vue-form-builder';
 import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
-import {useFormCapabilities} from '../helpers';
+import {triStateValueIsEnabled, useFormCapabilities} from '../helpers';
 import {setFieldRef} from '../form-builder/utils/createValueSetter';
 import {useQueryStore} from '../../stores';
 import {type CapabilitiesSelection} from './wireProxyCapabilities';
 import {readShipmentSnapshot} from './readShipmentSnapshot';
-import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
+import {FIELD_CARRIER, optionFieldName} from './field';
 
 /**
  * THE single point of reference for shipment-option field state. Every rule that decides an
@@ -21,11 +21,11 @@ import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
  *     carrier capability options ──┘         │
  *                                            ▼
  *                            Map<optionKey, OptionState>
- *                 {supported, visible, readOnly, forcedOn, forcedOff, targetValue}
+ *                       {supported, readOnly, forcedOn, forcedOff}
  *                          │                             │
- *              field hooks read flags          one watcher writes targetValue
- *              (visibleWhen/disabledWhen/      into the fields (locked with readOnly,
- *               readOnlyWhen = one lookup)      not disabled, so values still submit)
+ *              field hooks read flags          one watcher writes the forced
+ *              (visibleWhen/disabledWhen/      values into the fields (locked with
+ *               readOnlyWhen = one lookup)      readOnly, not disabled, so they submit)
  *
  * Why this shape (not a data-returning composable): the state is read by field hook closures
  * (`visibleWhen` / `readOnlyWhen` / `disabledWhen`) that vue-form-builder invokes outside Vue
@@ -35,23 +35,22 @@ import {FIELD_CARRIER, FIELD_SHIPMENT_OPTIONS_PREFIX} from './field';
  * `useFormCapabilities`.
  *
  * @TODO: fold useCapabilitiesAutoClear's option-reset (clearing active options the carrier no
- *        longer supports) into resolveOptionStates as well, so option-state truly has a single
- *        module.
+ *        longer supports) into resolveOptionStates as well — including one shared, silent
+ *        field-write path for both modules — so option-state truly has a single module.
+ * @TODO: non-toggle options (insurance, an int amount) are never treated as enabled here, so
+ *        their requires/excludes rules are not applied yet; scope per-option kinds when that
+ *        becomes relevant (the DO widget defers the same case).
  */
 
 export type OptionState = {
-  /** The current capability data contains this option at all. */
+  /** The current capability data contains this option at all; drives visibility. */
   supported: boolean;
-  /** The field is rendered (currently equal to `supported`). */
-  visible: boolean;
-  /** The field is locked: carrier-required, or forced on/off by another enabled option. */
+  /** The field is locked because the option is forced on or off. */
   readOnly: boolean;
-  /** Forced on through a requires relation or carrier isRequired. */
+  /** Forced on: carrier-required, or required by another enabled option. */
   forcedOn: boolean;
-  /** Forced off through an excludes relation. */
+  /** Forced off: excluded by another enabled option. */
   forcedOff: boolean;
-  /** The value the field must hold; written through by the composable so it persists. */
-  targetValue?: TriState;
 };
 
 export type OptionStateEntry = {
@@ -65,7 +64,7 @@ export type OptionStateEntry = {
 export type ResolveOptionStatesInput = {
   /**
    * Options from the regular fallback chain (shipment query → order query → dynamic context).
-   * Decides which options exist for the current carrier — i.e. `supported` / `visible`.
+   * Decides which options exist for the current carrier — i.e. `supported`.
    */
   availabilityOptions: CarrierModel['options'] | undefined;
   /**
@@ -79,21 +78,61 @@ export type ResolveOptionStatesInput = {
   entries: OptionStateEntry[];
 };
 
-/** State for options we know nothing about: visible and editable, nothing locked or forced. */
-const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
-  supported: true,
-  visible: true,
-  readOnly: false,
-  forcedOn: false,
-  forcedOff: false,
-});
+/* ---------------------------------------------------------------------------------------------
+ * Pure resolver — every option-state rule lives here.
+ * ------------------------------------------------------------------------------------------- */
 
 /**
- * An option counts as enabled when it's explicitly on, or inheriting while its inherited
- * default is on — the same interpretation `triStateFieldIsEnabled` applies elsewhere.
+ * Compute the complete state of every shipment option. Pure — all inputs in, one map out.
+ *
+ * Forcing rules, mirroring the server-side CapabilitiesOptionCalculator:
+ * - carrier-required options (`isRequired`) are forced on, including everything their
+ *   `requires` lists point to, directly or indirectly;
+ * - enabled options pull in everything their `requires` lists point to (the option itself
+ *   stays free — its own value is the user's choice);
+ * - `excludes` of every active option force the excluded options off;
+ * - on conflict, forced-off wins (the PHP calculator depends on iteration order here; real
+ *   data has no conflicting rules).
+ *
+ * @param input - See {@link ResolveOptionStatesInput}: the option map used for availability,
+ *   the option map used for rules (only from a matched shipment response), and one entry per
+ *   option field with its current form value and inherited default.
  */
-const isEffectivelyEnabled = (entry: OptionStateEntry): boolean =>
-  TriState.On === entry.value || (TriState.Inherit === entry.value && TriState.On === entry.defaultValue);
+export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string, OptionState> => {
+  const {availabilityOptions, shipmentOptions, entries} = input;
+
+  let forcedOn = new Set<string>();
+  let forcedOff = new Set<string>();
+
+  if (shipmentOptions) {
+    const enabledKeys = entries
+      .filter((entry) => triStateValueIsEnabled(entry.value, entry.defaultValue))
+      .map((entry) => entry.key);
+
+    forcedOn = resolveForcedOn(shipmentOptions, enabledKeys);
+    forcedOff = resolveForcedOff(shipmentOptions, new Set([...enabledKeys, ...forcedOn]));
+
+    for (const key of forcedOff) {
+      forcedOn.delete(key);
+    }
+  }
+
+  const states = new Map<string, OptionState>();
+
+  for (const entry of entries) {
+    const isForcedOn = forcedOn.has(entry.key);
+    const isForcedOff = forcedOff.has(entry.key);
+
+    states.set(entry.key, {
+      supported: Object.hasOwn(availabilityOptions ?? {}, entry.key),
+      readOnly: isForcedOn || isForcedOff,
+      forcedOn: isForcedOn,
+      forcedOff: isForcedOff,
+    });
+  }
+
+  return states;
+};
 
 /**
  * Collect every option that must be turned on. Starting from the carrier-required options and
@@ -102,24 +141,22 @@ const isEffectivelyEnabled = (entry: OptionStateEntry): boolean =>
  * so circular requires can't loop forever). Carrier-required options are included in the
  * result themselves; enabled options are not — their own value is the user's choice.
  *
- * @param shipmentOptions - The option map from the matched shipment-scoped capabilities response,
- *   keyed by capability option key (e.g. `requiresSignature`). Each entry may carry
+ * @param shipmentOptions - The option map from the matched shipment-scoped capabilities
+ *   response, keyed by capability option key (e.g. `requiresSignature`). Each entry may carry
  *   `isRequired`, `requires` and `excludes`.
  * @param enabledKeys - Capability option keys of the options that are currently on in the
  *   form (explicitly, or through their inherited default).
  */
 const resolveForcedOn = (shipmentOptions: NonNullable<CarrierModel['options']>, enabledKeys: string[]): Set<string> => {
-  const forcedOn = new Set<string>();
   const requiredKeys = Object.keys(shipmentOptions).filter((key) => shipmentOptions[key]?.isRequired === true);
-
-  requiredKeys.forEach((key) => forcedOn.add(key));
+  const forcedOn = new Set(requiredKeys);
 
   const queue = [...requiredKeys, ...enabledKeys];
   const visited = new Set(queue);
 
-  while (queue.length > 0) {
-    const key = queue.shift() as string;
-
+  // A for-of loop over an array visits items pushed during the loop, so the queue grows as
+  // new requires are discovered.
+  for (const key of queue) {
     for (const required of shipmentOptions[key]?.requires ?? []) {
       forcedOn.add(required);
 
@@ -155,78 +192,9 @@ const resolveForcedOff = (
   return forcedOff;
 };
 
-/**
- * Decide which value a field must be set to, if any. Returns undefined when the field may
- * keep its current value.
- *
- * @param entry - The option's key plus its current form value and inherited default.
- * @param isForcedOn - Whether the option is in the forced-on set.
- * @param isForcedOff - Whether the option is in the forced-off set.
- */
-const resolveTargetValue = (
-  entry: OptionStateEntry,
-  isForcedOn: boolean,
-  isForcedOff: boolean,
-): TriState | undefined => {
-  if (isForcedOn && TriState.On !== entry.value) return TriState.On;
-
-  if (isForcedOff && TriState.Off !== entry.value) return TriState.Off;
-
-  return undefined;
-};
-
-/**
- * Compute the complete state of every shipment option. Pure — all inputs in, one map out.
- *
- * Forcing rules, mirroring the server-side CapabilitiesOptionCalculator:
- * - carrier-required options (`isRequired`) are forced on, including everything their
- *   `requires` lists point to, directly or indirectly;
- * - enabled options pull in everything their `requires` lists point to (the option itself
- *   stays free — its own value is the user's choice);
- * - `excludes` of every active option force the excluded options off;
- * - on conflict, forced-off wins (the PHP calculator depends on iteration order here; real
- *   data has no conflicting rules).
- *
- * @param input - See {@link ResolveOptionStatesInput}: the option map used for availability,
- *   the option map used for rules (only from a matched shipment response), and one entry per
- *   option field with its current form value and inherited default.
- */
-export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string, OptionState> => {
-  const {availabilityOptions, shipmentOptions, entries} = input;
-
-  let forcedOn = new Set<string>();
-  let forcedOff = new Set<string>();
-
-  if (shipmentOptions) {
-    const enabledKeys = entries.filter(isEffectivelyEnabled).map((entry) => entry.key);
-
-    forcedOn = resolveForcedOn(shipmentOptions, enabledKeys);
-    forcedOff = resolveForcedOff(shipmentOptions, new Set([...enabledKeys, ...forcedOn]));
-
-    for (const key of forcedOff) {
-      forcedOn.delete(key);
-    }
-  }
-
-  const states = new Map<string, OptionState>();
-
-  for (const entry of entries) {
-    const supported = Object.hasOwn(availabilityOptions ?? {}, entry.key);
-    const isForcedOn = forcedOn.has(entry.key);
-    const isForcedOff = forcedOff.has(entry.key);
-
-    states.set(entry.key, {
-      supported,
-      visible: supported,
-      readOnly: isForcedOn || isForcedOff,
-      forcedOn: isForcedOn,
-      forcedOff: isForcedOff,
-      targetValue: resolveTargetValue(entry, isForcedOn, isForcedOff),
-    });
-  }
-
-  return states;
-};
+/* ---------------------------------------------------------------------------------------------
+ * Form wiring — feeds the resolver reactively and exposes the resolved states.
+ * ------------------------------------------------------------------------------------------- */
 
 /**
  * Identifies the per-order shipment capabilities query: the order id it is registered under
@@ -239,26 +207,13 @@ type ShipmentQueryContext = {
 
 const formStates = new WeakMap<FormInstance, Ref<Map<string, OptionState>>>();
 
-const optionFieldName = (key: string): string => `${FIELD_SHIPMENT_OPTIONS_PREFIX}.${key}`;
-
-/**
- * Read a single option's resolved state. Field hooks (`visibleWhen` / `disabledWhen` /
- * `readOnlyWhen`) call this — reading `states.value` inside those reactive re-evaluators
- * makes them re-run whenever the states are recomputed. Forms that never registered with
- * {@link useShipmentOptionsState} (e.g. field-factory unit tests) get a neutral state that
- * leaves the field visible and editable.
- *
- * @param form - The shipment-options form the option field belongs to.
- * @param optionKey - The capability option key: the part after the last dot of the field
- *   name (`requiresSignature` for the field `deliveryOptions.shipmentOptions.requiresSignature`).
- */
-export const getOptionState = (form: FormInstance, optionKey: string): OptionState => {
-  const states = formStates.get(form);
-
-  if (!states) return NEUTRAL_OPTION_STATE;
-
-  return states.value.get(optionKey) ?? NEUTRAL_OPTION_STATE;
-};
+/** State for options we know nothing about: visible and editable, nothing locked or forced. */
+const NEUTRAL_OPTION_STATE: OptionState = Object.freeze({
+  supported: true,
+  readOnly: false,
+  forcedOn: false,
+  forcedOff: false,
+});
 
 /**
  * Connect the option-state resolver to a shipment-options form. States are recomputed when
@@ -301,15 +256,15 @@ export const useShipmentOptionsState = (
       snapshot: shipmentQuery
         ? readShipmentSnapshot(shipmentQuery.selection, queryStore, shipmentQuery.orderId)
         : undefined,
+      // The shipment response only applies while the form still shows the carrier it was
+      // fetched for; right after a carrier switch the (debounced) query still holds the old
+      // carrier's data.
+      selectionMatchesForm:
+        Boolean(shipmentQuery) && form.getValue(FIELD_CARRIER) === shipmentQuery?.selection.value.carrier,
       availabilityOptions: capabilities.getCarrierCapabilitiesForShipment(form)?.options,
       entries: readEntries(form, allOptionKeys),
-      carrier: form.getValue(FIELD_CARRIER) as string | undefined,
     }),
-    ({snapshot, availabilityOptions, entries, carrier}) => {
-      // The response only applies when the form still shows the carrier it was fetched for;
-      // right after a carrier switch the (debounced) query still holds the old carrier's data.
-      const selectionMatchesForm = Boolean(shipmentQuery) && carrier === shipmentQuery?.selection.value.carrier;
-
+    ({snapshot, selectionMatchesForm, availabilityOptions, entries}) => {
       // A reload for the same carrier (e.g. after a weight change): keep the current locks
       // until the new response arrives, instead of unlocking everything in the meantime.
       if (snapshot?.state === 'pending' && selectionMatchesForm && states.value.size > 0) {
@@ -322,10 +277,29 @@ export const useShipmentOptionsState = (
       const next = resolveOptionStates({availabilityOptions, shipmentOptions, entries});
 
       states.value = next;
-      applyTargetValues(form, next);
+      applyForcedValues(form, next);
     },
     {immediate: true},
   );
+};
+
+/**
+ * Read a single option's resolved state. Field hooks (`visibleWhen` / `disabledWhen` /
+ * `readOnlyWhen`) call this — reading `states.value` inside those reactive re-evaluators
+ * makes them re-run whenever the states are recomputed. Forms that never registered with
+ * {@link useShipmentOptionsState} (e.g. field-factory unit tests) get a neutral state that
+ * leaves the field visible and editable.
+ *
+ * @param form - The shipment-options form the option field belongs to.
+ * @param optionKey - The capability option key: the part after the last dot of the field
+ *   name (`requiresSignature` for the field `deliveryOptions.shipmentOptions.requiresSignature`).
+ */
+export const getOptionState = (form: FormInstance, optionKey: string): OptionState => {
+  const states = formStates.get(form);
+
+  if (!states) return NEUTRAL_OPTION_STATE;
+
+  return states.value.get(optionKey) ?? NEUTRAL_OPTION_STATE;
 };
 
 /**
@@ -347,23 +321,25 @@ const readEntries = (form: FormInstance, allOptionKeys: string[]): OptionStateEn
   });
 
 /**
- * Write every resolved `targetValue` into its field. Fields that already hold the value are
- * skipped — the watcher runs again after each write, and because unchanged values are skipped
- * it stops by itself once every forced value is in place.
+ * Write the forced value (on for forced-on, off for forced-off) into every affected field.
+ * Fields that already hold the value are skipped — the watcher runs again after each write,
+ * and because unchanged values are skipped it stops by itself once every forced value is in
+ * place.
  *
  * @param form - The form whose option fields receive the forced values.
  * @param states - The resolved states from {@link resolveOptionStates}, keyed by capability
  *   option key.
  */
-const applyTargetValues = (form: FormInstance, states: Map<string, OptionState>): void => {
+const applyForcedValues = (form: FormInstance, states: Map<string, OptionState>): void => {
   for (const [key, state] of states) {
-    if (state.targetValue === undefined) continue;
+    if (!state.forcedOn && !state.forcedOff) continue;
 
+    const forcedValue = state.forcedOn ? TriState.On : TriState.Off;
     const fieldName = optionFieldName(key);
     const field = form.getField(fieldName);
 
-    if (!field || form.getValue(fieldName) === state.targetValue) continue;
+    if (!field || form.getValue(fieldName) === forcedValue) continue;
 
-    setFieldRef(field as InteractiveElementInstance, state.targetValue);
+    setFieldRef(field as InteractiveElementInstance, forcedValue);
   }
 };

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.ts
@@ -4,8 +4,10 @@ import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
 import {triStateValueIsEnabled, useFormCapabilities} from '../helpers';
 import {setFieldRef} from '../form-builder/utils/createValueSetter';
 import {useQueryStore} from '../../stores';
+import {globalLogger} from '../../services';
 import {type CapabilitiesSelection} from './wireProxyCapabilities';
 import {readShipmentSnapshot} from './readShipmentSnapshot';
+import {fieldFactoryRegistry} from './fieldFactoryRegistry';
 import {FIELD_CARRIER, optionFieldName} from './field';
 
 /**
@@ -82,13 +84,7 @@ export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string
       .filter((entry) => triStateValueIsEnabled(entry.value, entry.defaultValue))
       .map((entry) => entry.key);
 
-    forcedOn = resolveForcedOn(shipmentOptions, enabledKeys);
-    forcedOff = resolveForcedOff(shipmentOptions, new Set([...enabledKeys, ...forcedOn]));
-
-    // On conflict, forced-off wins -- normally data should have no conflicting rules.
-    for (const key of forcedOff) {
-      forcedOn.delete(key);
-    }
+    ({forcedOn, forcedOff} = resolveForcedStates(shipmentOptions, enabledKeys));
   }
 
   const states = new Map<string, OptionState>();
@@ -109,54 +105,82 @@ export const resolveOptionStates = (input: ResolveOptionStatesInput): Map<string
 };
 
 /**
- * Collect every option that must be turned on, following `requires` lists transitively.
+ * Apply the requires and excludes rules of the enabled options. If two rules disagree, the first
+ * rule has effect. The resolver writes a warning about the other rule.
  *
  * @param shipmentOptions - The option map from the matched shipment-scoped response.
  * @param enabledKeys - Capability option keys of the options that are currently on.
  */
-const resolveForcedOn = (shipmentOptions: NonNullable<CarrierModel['options']>, enabledKeys: string[]): Set<string> => {
+const resolveForcedStates = (
+  shipmentOptions: NonNullable<CarrierModel['options']>,
+  enabledKeys: string[],
+): {forcedOn: Set<string>; forcedOff: Set<string>} => {
   const requiredKeys = Object.keys(shipmentOptions).filter((key) => shipmentOptions[key]?.isRequired === true);
 
-  // Carrier-required options force themselves; enabled options only force what they require —
-  // their own value stays the user's choice.
+  // The carrier requires these options. These options are on and locked.
   const forcedOn = new Set(requiredKeys);
+  const forcedOff = new Set<string>();
 
-  // `visited` skips options that were already walked, so circular requires can't loop forever.
-  const queue = [...requiredKeys, ...enabledKeys];
-  const visited = new Set(queue);
+  // The rules come from two groups of options: the group that the carrier requires, and the group
+  // that is enabled on the order. An option can be in both groups, and thus the set removes the
+  // duplicates. An enabled option is a source of rules only. It does not force its own value, and
+  // the user keeps control of that value.
+  const ruleSources = new Set([...requiredKeys, ...enabledKeys]);
 
-  // A for-of loop over an array visits items pushed during the loop, so the queue grows as
-  // new requires are discovered.
+  // The queue holds the options that the loop must still read. The visited set prevents an endless
+  // loop if two options require each other.
+  const queue = [...ruleSources];
+  const visited = new Set(ruleSources);
+
+  // A for-of loop over an array also reads the items that the loop adds. The queue thus becomes
+  // longer while the loop finds more requires rules.
   for (const key of queue) {
     for (const required of shipmentOptions[key]?.requires ?? []) {
+      if (forcedOff.has(required)) {
+        logRuleConflict(required, key, 'require', 'excluded');
+
+        continue;
+      }
+
       forcedOn.add(required);
 
       if (!visited.has(required)) {
+        // Add the option to the end of the queue. The rules of the enabled options apply first.
+        // The rules of an option from a requires chain apply after them.
         visited.add(required);
         queue.push(required);
       }
     }
-  }
 
-  return forcedOn;
-};
-
-/**
- * Collect the `excludes` of every active option (enabled plus forced-on) into the forced-off set.
- */
-const resolveForcedOff = (
-  shipmentOptions: NonNullable<CarrierModel['options']>,
-  activeKeys: Set<string>,
-): Set<string> => {
-  const forcedOff = new Set<string>();
-
-  for (const key of activeKeys) {
     for (const excluded of shipmentOptions[key]?.excludes ?? []) {
+      if (forcedOn.has(excluded)) {
+        logRuleConflict(excluded, key, 'exclude', 'required');
+
+        continue;
+      }
+
       forcedOff.add(excluded);
     }
   }
 
-  return forcedOff;
+  return {forcedOn, forcedOff};
+};
+
+/**
+ * Write a warning about a rule that the resolver does not apply. The capabilities data has a
+ * conflict. Correct the data at the source.
+ *
+ * @param optionKey - Option the rule points at.
+ * @param sourceKey - Option that holds the rule.
+ * @param action - `require` or `exclude`.
+ * @param state - `required` or `excluded`.
+ */
+const logRuleConflict = (optionKey: string, sourceKey: string, action: string, state: string): void => {
+  globalLogger.warn(
+    'useShipmentOptionsState',
+    `Can't ${action} "${optionKey}", it's already ${state} by another option; capabilities rules contradict each other.`,
+    {option: optionKey, source: sourceKey, action, state},
+  );
 };
 
 /* ---------------------------------------------------------------------------------------------
@@ -290,10 +314,16 @@ const readEntries = (form: FormInstance, allOptionKeys: string[]): OptionStateEn
  * Write the forced value (on for forced-on, off for forced-off) into every affected field.
  * Forced fields are locked with readOnly, not disabled, so their values still submit and
  * end up stored on the order.
+ *
+ * A required option that has a custom field factory keeps its value. The user must set that value.
  */
 const applyForcedValues = (form: FormInstance, states: Map<string, OptionState>): void => {
   for (const [key, state] of states) {
     if (!state.forcedOn && !state.forcedOff) continue;
+
+    // A custom field holds a range of values instead of a toggle. A rule that requires the option
+    // does not give one value. The user must set the amount, and export applies the rule again.
+    if (state.forcedOn && Object.hasOwn(fieldFactoryRegistry, key)) continue;
 
     const forcedValue = state.forcedOn ? TriState.On : TriState.Off;
     const fieldName = optionFieldName(key);

--- a/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.visibility.spec.ts
+++ b/apps/admin/src/forms/shipmentOptions/useShipmentOptionsState.visibility.spec.ts
@@ -1,0 +1,105 @@
+import {effectScope, nextTick, ref, toValue} from 'vue';
+import {describe, expect, it, vi, beforeEach} from 'vitest';
+import {defineForm, type FormInstance} from '@myparcel-dev/vue-form-builder';
+import {type CarrierModel, TriState} from '@myparcel-dev/pdk-common';
+import {useShipmentOptionsState} from './useShipmentOptionsState';
+import {createShipmentOptionField} from './fields/createShipmentOptionField';
+import {FIELD_CARRIER, optionFieldName} from './field';
+
+/**
+ * Integration spec for the path the unit spec cannot cover: the option states reaching the
+ * REAL vue-form-builder elements. The form-builder evaluates every field hook once,
+ * synchronously, while the fields are constructed inside `defineForm` — BEFORE
+ * `useShipmentOptionsState` has registered the form. That first evaluation must still
+ * subscribe to the (not yet registered) option states, or `isVisible` freezes on its initial
+ * value and unsupported options render forever. This is exactly what happened live when the
+ * registry was a WeakMap: a WeakMap read is not a reactive dependency.
+ */
+
+const getCarrierCapabilitiesForShipmentMock = vi.fn();
+
+vi.mock('../helpers', () => ({
+  // Mirrors the real triStateValueIsEnabled. Kept inline: awaiting an import inside this
+  // factory deadlocks vitest through the helpers barrel's own import chain.
+  triStateValueIsEnabled: (value: unknown, defaultValue: unknown) =>
+    value === TriState.Inherit ? defaultValue === TriState.On : value === TriState.On,
+  useFormCapabilities: () => ({
+    getCarrierCapabilitiesForShipment: getCarrierCapabilitiesForShipmentMock,
+  }),
+  defineFormField: (config: unknown) => config,
+  getFieldLabel: (name: string) => name,
+  resolveFormComponent: () => 'div',
+}));
+
+vi.mock('../../stores', () => ({
+  useQueryStore: () => ({
+    has: () => false,
+    get: () => ({status: ref('idle'), data: ref(undefined)}),
+  }),
+}));
+
+vi.mock('../form-builder/utils/createValueSetter', () => ({
+  setFieldRef: (field: {ref: {value: unknown}}, value: unknown) => {
+    field.ref.value = value;
+  },
+}));
+
+const OPTION_KEYS = ['requiresSignature', 'frozen'];
+
+/**
+ * Wait for the form-builder's hook effects: the recompute watcher runs on the pre queue
+ * (first nextTick), and the form-builder writes each hook result into its element ref in a
+ * promise callback after re-evaluating (second round).
+ */
+const flushHookEffects = async (): Promise<void> => {
+  await nextTick();
+  await nextTick();
+  await Promise.resolve();
+};
+
+const isFieldVisible = (form: FormInstance, optionKey: string): boolean =>
+  toValue((form.getField(optionFieldName(optionKey)) as unknown as {isVisible: unknown}).isVisible) as boolean;
+
+describe('option visibility on real form elements', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides unsupported options even though hooks first run before the module registers', async () => {
+    const availability = ref<CarrierModel['options']>({requiresSignature: {}});
+
+    getCarrierCapabilitiesForShipmentMock.mockImplementation(() => ({options: availability.value}));
+
+    const scope = effectScope();
+
+    await scope.run(async () => {
+      // Constructing the form evaluates every visibleWhen immediately — before registration.
+      const form = defineForm('element-visibility', {
+        fields: [
+          {name: FIELD_CARRIER, component: 'div', ref: ref('CARRIER_A')},
+          ...OPTION_KEYS.map((key) => createShipmentOptionField({}, optionFieldName(key))),
+        ],
+      }) as unknown as FormInstance;
+
+      // Before registration every option falls back to the neutral state: visible.
+      expect(isFieldVisible(form, 'frozen')).toBe(true);
+
+      useShipmentOptionsState(form, OPTION_KEYS);
+      await flushHookEffects();
+
+      // After registration the carrier's availability reaches the elements: the supported
+      // option stays visible, the unsupported one is hidden.
+      expect(isFieldVisible(form, 'requiresSignature')).toBe(true);
+      expect(isFieldVisible(form, 'frozen')).toBe(false);
+
+      // Availability changes (e.g. another carrier's capabilities arriving) flow through
+      // reactively to the same elements.
+      availability.value = {requiresSignature: {}, frozen: {}};
+      await flushHookEffects();
+
+      expect(isFieldVisible(form, 'frozen')).toBe(true);
+    });
+
+    scope.stop();
+  });
+});

--- a/libs/checkout-delivery-options/src/listeners/updateConfigOrAddress.spec.ts
+++ b/libs/checkout-delivery-options/src/listeners/updateConfigOrAddress.spec.ts
@@ -1,0 +1,89 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {tests, usePdkCheckout} from '@myparcel-dev/pdk-checkout-common';
+import {UPDATE_CONFIG_IN} from '@myparcel-dev/delivery-options';
+import {initializeCheckoutDeliveryOptions} from '../initializeCheckoutDeliveryOptions';
+import {useDeliveryOptionsStore} from '../utils';
+
+/** @vitest-environment happy-dom */
+
+const DEBOUNCE_MS = 150;
+
+const setupStore = async (): Promise<ReturnType<typeof useDeliveryOptionsStore>> => {
+  await tests.mockPdkCheckout();
+
+  usePdkCheckout().onInitialize(() => initializeCheckoutDeliveryOptions());
+
+  // The config event only goes out when the delivery options are on screen, which the code
+  // recognises by the element having content.
+  const element = document.querySelector('#delivery-options');
+
+  if (element) {
+    element.innerHTML = '<div>delivery options</div>';
+  }
+
+  const deliveryOptions = useDeliveryOptionsStore();
+
+  // Give the store a starting point to compare against, then let the debounce settle so only
+  // the update under test can fire an event.
+  await deliveryOptions.set({
+    configuration: {
+      ...deliveryOptions.state.configuration,
+      config: {},
+      cartShipmentOptions: {postnl: {signature: true}},
+    },
+  });
+
+  vi.advanceTimersByTime(DEBOUNCE_MS);
+
+  return deliveryOptions;
+};
+
+describe('updateConfigOrAddress', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('tells the delivery options when only the cart shipment options changed', async () => {
+    const deliveryOptions = await setupStore();
+    const listener = vi.fn();
+
+    document.addEventListener(UPDATE_CONFIG_IN, listener);
+
+    await deliveryOptions.set({
+      configuration: {
+        ...deliveryOptions.state.configuration,
+        cartShipmentOptions: {postnl: {signature: true, onlyRecipient: true}},
+      },
+    });
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    document.removeEventListener(UPDATE_CONFIG_IN, listener);
+  });
+
+  it('stays quiet when nothing in the configuration changed', async () => {
+    const deliveryOptions = await setupStore();
+    const listener = vi.fn();
+
+    document.addEventListener(UPDATE_CONFIG_IN, listener);
+
+    await deliveryOptions.set({
+      configuration: {
+        ...deliveryOptions.state.configuration,
+        cartShipmentOptions: {postnl: {signature: true}},
+      },
+    });
+
+    vi.advanceTimersByTime(DEBOUNCE_MS);
+
+    expect(listener).not.toHaveBeenCalled();
+
+    document.removeEventListener(UPDATE_CONFIG_IN, listener);
+  });
+});

--- a/libs/checkout-delivery-options/src/listeners/updateConfigOrAddress.ts
+++ b/libs/checkout-delivery-options/src/listeners/updateConfigOrAddress.ts
@@ -11,12 +11,19 @@ import {type DeliveryOptionsStoreState} from '../types';
 export const updateConfigOrAddress: StoreCallbackUpdate<DeliveryOptionsStoreState> = debounce((newState, oldState) => {
   const triggerEvent = useUtil(PdkUtil.TriggerEvent);
 
-  const {config: newConfig, address: newAddress} = newState.configuration ?? {};
-  const {config: oldConfig, address: oldAddress} = oldState?.configuration ?? {};
+  const {config: newConfig, address: newAddress, cartShipmentOptions: newCartOptions} = newState.configuration ?? {};
+  const {config: oldConfig, address: oldAddress, cartShipmentOptions: oldCartOptions} = oldState?.configuration ?? {};
 
   const isRendered = deliveryOptionsIsRendered();
 
-  if (isRendered && oldConfig && !objectIsEqual(newConfig, oldConfig)) {
+  // The cart's shipment options are part of the configuration the delivery options read, so a
+  // change in them has to reach them the same way a config change does. Without this, options
+  // the cart starts or stops forcing (like the ones age check requires) would only show up on
+  // the next config or address change.
+  const configChanged =
+    !objectIsEqual(newConfig, oldConfig) || !objectIsEqual(newCartOptions ?? {}, oldCartOptions ?? {});
+
+  if (isRendered && oldConfig && configChanged) {
     // If the delivery options are rendered and config has changed, send 'update_config' event
     triggerEvent(UPDATE_CONFIG_IN, newState.configuration);
   } else if (newState.enabled && (!isRendered || !oldConfig || !objectIsEqual(newAddress, oldAddress))) {

--- a/libs/checkout-delivery-options/src/store/createDeliveryOptionsStore.ts
+++ b/libs/checkout-delivery-options/src/store/createDeliveryOptionsStore.ts
@@ -9,7 +9,7 @@ export const createDeliveryOptionsStore = (settings?: CheckoutDeliveryOptionsSet
 
   const checkout = useCheckoutStore();
 
-  const {config, strings} = checkout.state.context;
+  const {config, strings, cartShipmentOptions} = checkout.state.context;
 
   return createStore<DeliveryOptionsStoreState>(Symbol('deliveryOptions'), () => {
     return {
@@ -23,6 +23,7 @@ export const createDeliveryOptionsStore = (settings?: CheckoutDeliveryOptionsSet
           address: getDeliveryOptionsAddress(),
           config,
           strings,
+          cartShipmentOptions,
         },
 
         /**

--- a/libs/checkout-delivery-options/src/types/store.types.ts
+++ b/libs/checkout-delivery-options/src/types/store.types.ts
@@ -4,6 +4,11 @@ import {type CheckoutDeliveryOptionsSettings} from './generic.types';
 
 export type DeliveryOptionsStoreState = {
   settings: CheckoutDeliveryOptionsSettings;
+
+  /**
+   * The configuration passed to the delivery options library, including the cart's active
+   * shipment options from the checkout context.
+   */
   configuration: InputDeliveryOptionsConfiguration;
   enabled: boolean;
   hiddenInput?: HTMLInputElement;

--- a/libs/checkout-delivery-options/src/utils/updateContext.spec.ts
+++ b/libs/checkout-delivery-options/src/utils/updateContext.spec.ts
@@ -1,0 +1,50 @@
+import {describe, expect, it} from 'vitest';
+import {tests, usePdkCheckout} from '@myparcel-dev/pdk-checkout-common';
+import {initializeCheckoutDeliveryOptions} from '../initializeCheckoutDeliveryOptions';
+import {useDeliveryOptionsStore} from './useDeliveryOptionsStore';
+import {updateContext} from './updateContext';
+
+/** @vitest-environment happy-dom */
+
+const EXISTING_CART_OPTIONS = {postnl: {signature: true}};
+const FRESH_CART_OPTIONS = {postnl: {ageCheck: true, signature: true, onlyRecipient: true}};
+
+const doTestSetup = async (): Promise<void> => {
+  await tests.mockPdkCheckout();
+
+  usePdkCheckout().onInitialize(() => initializeCheckoutDeliveryOptions());
+
+  const deliveryOptions = useDeliveryOptionsStore();
+
+  await deliveryOptions.set({
+    configuration: {
+      ...deliveryOptions.state.configuration,
+      cartShipmentOptions: EXISTING_CART_OPTIONS,
+    },
+  });
+};
+
+describe('updateContext', () => {
+  it('replaces the cart shipment options when the fresh context carries them', async () => {
+    await doTestSetup();
+
+    tests.doRequestSpy.mockResolvedValueOnce({
+      data: {context: [{checkout: {config: {}, strings: {}, cartShipmentOptions: FRESH_CART_OPTIONS}}]},
+    });
+
+    await updateContext();
+
+    expect(useDeliveryOptionsStore().state.configuration.cartShipmentOptions).toEqual(FRESH_CART_OPTIONS);
+  });
+
+  it('keeps the known cart shipment options when the context omits them', async () => {
+    await doTestSetup();
+
+    // Older PDK versions don't send the key, and a failed fetch falls back to an empty context.
+    tests.doRequestSpy.mockResolvedValueOnce({data: {context: [{checkout: {config: {}, strings: {}}}]}});
+
+    await updateContext();
+
+    expect(useDeliveryOptionsStore().state.configuration.cartShipmentOptions).toEqual(EXISTING_CART_OPTIONS);
+  });
+});

--- a/libs/checkout-delivery-options/src/utils/updateContext.ts
+++ b/libs/checkout-delivery-options/src/utils/updateContext.ts
@@ -27,7 +27,9 @@ export const updateContext = async (): Promise<void> => {
         },
         // Pass **all** the shipment options from the cart, so that the delivery options can render excludes/requires
         // Ex. "age check" is not selectable in the DO but it makes signature/onlyRecipient mandatory.
-        cartShipmentOptions: context.cartShipmentOptions,
+        // Replaced wholesale when present; kept when the context omits the key (older PDK
+        // versions, or the empty-context fallback after a failed fetch).
+        cartShipmentOptions: context.cartShipmentOptions ?? deliveryOptions.state.configuration.cartShipmentOptions,
       },
     }),
   ]);

--- a/libs/checkout-delivery-options/src/utils/updateContext.ts
+++ b/libs/checkout-delivery-options/src/utils/updateContext.ts
@@ -25,6 +25,9 @@ export const updateContext = async (): Promise<void> => {
           ...deliveryOptions.state.configuration.strings,
           ...context.strings,
         },
+        // Pass **all** the shipment options from the cart, so that the delivery options can render excludes/requires
+        // Ex. "age check" is not selectable in the DO but it makes signature/onlyRecipient mandatory.
+        cartShipmentOptions: context.cartShipmentOptions,
       },
     }),
   ]);

--- a/libs/common/src/types/php-pdk.types.ts
+++ b/libs/common/src/types/php-pdk.types.ts
@@ -348,6 +348,8 @@ export namespace Plugin {
   };
 
   export type ModelContextCheckoutContext = {
+    // Per carrier: camelCase option name → whether the cart's calculated order ships with it.
+    cartShipmentOptions?: Record<string, Record<string, boolean>>;
     config: Shipment.ModelDeliveryOptions;
     platformConfig: Record<'carriers', unknown[]>; // @todo this is a temporary generic type, until capabilities is implemented in the deliveryOptions
     endpoints: EndpointRequestCollection;


### PR DESCRIPTION
Enforces carrier capability rules on shipment options across the admin, and passes the cart's shipment options to the checkout widget.

When a merchant enables an option like age check (18+), the carrier's capability rules say other options (signature, only recipient) must be on as well. The admin now applies those rules everywhere: the carrier settings screen writes the forced values (toggles emit TriState ints, so the PHP-defined rules actually fire), the order form shows only the chosen carrier's options and locks forced ones at render, and the checkout context passes the cart's calculated shipment options to the delivery options widget so it can lock them for the consumer too.

One module per form now owns all option state (useShipmentOptionsState): availability, locking and forced values resolve in one pure function, and the field hooks only read the result. This also fixes a bug where every carrier's options rendered on every order: the hook registry wasn't reactive, so the resolved visibility never reached the fields.

Note: the typecheck job fails on updateContext.ts until @myparcel-dev/delivery-options ships cartShipmentOptions in its input type. Merge order: the delivery-options PR for INT-1596 first, then bump the dependency here.

Merge order for INT-1596:
1. myparcelnl/delivery-options#480 — its release adds cartShipmentOptions to the widget input.
2. This PR — bump @myparcel-dev/delivery-options afterwards to turn the typecheck green.
3. myparcelnl/pdk#510 — independent, can merge any time.

Fixes INT-1596
Subtask: INT-1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)