### PR TITLE
fix(insurance): read insurance limits from the flat capabilities format

### DIFF
--- a/apps/admin/src/forms/helpers/useFormCapabilities.spec.ts
+++ b/apps/admin/src/forms/helpers/useFormCapabilities.spec.ts
@@ -182,11 +182,9 @@ describe('useFormCapabilities', () => {
         carrier: 'POSTNL',
         options: {
           insurance: {
-            insuredAmount: {
-              min: {amount: 0, currency: 'EUR'},
-              max: {amount: 0, currency: 'EUR'},
-              default: {amount: 0, currency: 'EUR'},
-            },
+            min: {amount: 0, currency: 'EUR'},
+            max: {amount: 0, currency: 'EUR'},
+            default: {amount: 0, currency: 'EUR'},
           } as never,
         },
       });
@@ -202,12 +200,10 @@ describe('useFormCapabilities', () => {
         carrier: 'POSTNL',
         options: {
           insurance: {
-            insuredAmount: {
-              min: {amount: 0, currency: 'EUR'},
-              // max is 1000€ in cents
-              max: {amount: 100_000, currency: 'EUR'},
-              default: {amount: 0, currency: 'EUR'},
-            },
+            min: {amount: 0, currency: 'EUR'},
+            // max is 1000€ in cents
+            max: {amount: 100_000, currency: 'EUR'},
+            default: {amount: 0, currency: 'EUR'},
           } as never,
         },
       });
@@ -222,6 +218,22 @@ describe('useFormCapabilities', () => {
       // 0, 250, 500 (low steps) — then 1000 (high step from 500). Exact sequence verifies
       // the boundary semantics — replacing `<` with `<=` on LOW_THRESHOLD would shift these.
       expect(values.slice(1)).toEqual(['0', '25000', '50000', '100000']);
+    });
+
+    it('returns [] when the carrier advertises insurance without limits', async () => {
+      // Stored carrier data that predates the flat limits: insurance is offered, but there is
+      // no max to build brackets up to, so there is nothing to enumerate into the dropdown.
+      const shipment = buildCarrier({
+        carrier: 'POSTNL',
+        options: {
+          insurance: {isRequired: false, isSelectedByDefault: false} as never,
+        },
+      });
+      queryStore.setQuery(shipmentModifier('order-1'), 'success', [shipment]);
+
+      const {useFormCapabilities} = await import('./useFormCapabilities');
+
+      expect(useFormCapabilities().getInsuranceOptions(formStub('POSTNL'), formatter)).toEqual([]);
     });
   });
 });

--- a/apps/admin/src/forms/helpers/useFormCapabilities.ts
+++ b/apps/admin/src/forms/helpers/useFormCapabilities.ts
@@ -7,12 +7,6 @@ import {type AdminContext, type SelectOption} from '../../types';
 import {useQueryStore, type ResolvedQuery} from '../../stores';
 import {Format, type Formatter} from '../../composables';
 
-interface InsuranceAmountData {
-  min?: {amount: number; currency: string};
-  max?: {amount: number; currency: string};
-  default?: {amount: number; currency: string};
-}
-
 /**
  * Bag of capability resolvers, each pre-bound to a Pinia store + orderId snapshot captured at
  * the composable's invocation time. Returned by {@link useFormCapabilities}.
@@ -78,11 +72,10 @@ export type FormCapabilities = {
  * window focus, so we read `query.data` live on every resolver call rather than snapshotting
  * the carriers array at setup time.
  */
+// eslint-disable-next-line max-lines-per-function
 export const useFormCapabilities = (): FormCapabilities => {
   const queryStore = useQueryStore();
-  const dynamicContextQuery = queryStore.get(BackendEndpoint.FetchContext, AdminContextKey.Dynamic) as ResolvedQuery<
-    BackendEndpoint.FetchContext
-  >;
+  const dynamicContextQuery = queryStore.get(BackendEndpoint.FetchContext, AdminContextKey.Dynamic);
   const orderId = getOrderId();
 
   const orderModifier = typeof orderId === 'string' ? `${orderId}.order` : undefined;
@@ -95,7 +88,7 @@ export const useFormCapabilities = (): FormCapabilities => {
 
     if (toValue(query.status) !== 'success') return undefined;
 
-    return (toValue(query.data) ?? []) as CarrierModel[];
+    return toValue(query.data) ?? [];
   };
 
   const liveDynamicCarriers = (): CarrierModel[] => {
@@ -143,10 +136,10 @@ export const useFormCapabilities = (): FormCapabilities => {
     const STEP_THRESHOLD = 500;
 
     const carrier = getCarrierCapabilitiesForShipment(form);
-    const insuranceData = (carrier?.options?.insurance ?? {}) as InsuranceAmountData;
+    const insuranceData = carrier?.options?.insurance;
 
-    const min = insuranceData.min?.amount ? insuranceData.min.amount / 100 : 0;
-    const max = insuranceData.max?.amount ? insuranceData.max.amount / 100 : 0;
+    const min = insuranceData?.min?.amount ? insuranceData.min.amount / 100 : 0;
+    const max = insuranceData?.max?.amount ? insuranceData.max.amount / 100 : 0;
 
     if (max === 0) return [];
 

--- a/apps/admin/src/forms/helpers/useFormCapabilities.ts
+++ b/apps/admin/src/forms/helpers/useFormCapabilities.ts
@@ -8,11 +8,9 @@ import {useQueryStore, type ResolvedQuery} from '../../stores';
 import {Format, type Formatter} from '../../composables';
 
 interface InsuranceAmountData {
-  insuredAmount?: {
-    min: {amount: number; currency: string};
-    max: {amount: number; currency: string};
-    default: {amount: number; currency: string};
-  };
+  min?: {amount: number; currency: string};
+  max?: {amount: number; currency: string};
+  default?: {amount: number; currency: string};
 }
 
 /**
@@ -53,8 +51,8 @@ export type FormCapabilities = {
   hasShipmentOption: (form: FormInstance, option: string) => boolean;
 
   /**
-   * Insurance amount bracket options derived from the currently selected carrier's
-   * `insuredAmount` data. Amounts in the context are in cents; emitted values are strings
+   * Insurance amount bracket options derived from the currently selected carrier's insurance
+   * limits (`min` / `max`). Amounts in the context are in cents; emitted values are strings
    * representing cent amounts so they round-trip through form select inputs unchanged.
    */
   getInsuranceOptions: (form: FormInstance, formatter: Formatter) => SelectOption[];
@@ -147,8 +145,8 @@ export const useFormCapabilities = (): FormCapabilities => {
     const carrier = getCarrierCapabilitiesForShipment(form);
     const insuranceData = (carrier?.options?.insurance ?? {}) as InsuranceAmountData;
 
-    const min = insuranceData.insuredAmount?.min.amount ? insuranceData.insuredAmount.min.amount / 100 : 0;
-    const max = insuranceData.insuredAmount?.max.amount ? insuranceData.insuredAmount.max.amount / 100 : 0;
+    const min = insuranceData.min?.amount ? insuranceData.min.amount / 100 : 0;
+    const max = insuranceData.max?.amount ? insuranceData.max.amount / 100 : 0;
 
     if (max === 0) return [];
 

--- a/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
+++ b/apps/admin/src/forms/shipmentOptions/createShipmentOptionsForm.ts
@@ -86,7 +86,7 @@ export const createShipmentOptionsForm = (orders?: OneOrMore<Plugin.ModelPdkOrde
  * `hasShipmentOption`, which checks whether the currently selected carrier
  * supports each option.
  *
- * Runtime carrier-specific data (isRequired, insuredAmount, etc.) is read
+ * Runtime carrier-specific data (isRequired, insurance limits, etc.) is read
  * from the currently selected carrier via `getCarrier(form)`, not from
  * creation-time option data.
  */

--- a/apps/admin/src/forms/shipmentOptions/fieldFactoryRegistry.ts
+++ b/apps/admin/src/forms/shipmentOptions/fieldFactoryRegistry.ts
@@ -18,8 +18,8 @@ export type FieldFactory = (refs: ShipmentOptionsRefs, fieldName: string) => Int
  * `carrier.options`) to its custom factory function.
  *
  * Current exceptions:
- * - `insurance`: renders as a select/dropdown with amount brackets derived from
- *   `insuredAmount` in the option data.
+ * - `insurance`: renders as a select/dropdown with amount brackets derived from the
+ *   `min` / `max` limits in the option data.
  */
 export const fieldFactoryRegistry: Record<string, FieldFactory> = {
   insurance: createInsuranceField,

--- a/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
+++ b/apps/admin/src/forms/shipmentOptions/fields/createInsuranceField.ts
@@ -13,7 +13,7 @@ import {createRef} from './createRef';
  * Custom field factory for the insurance shipment option.
  *
  * Renders as a select/dropdown instead of a TriState toggle. Insurance amount brackets are
- * derived from the currently selected carrier's shipment-scoped `insuredAmount` data (min/max)
+ * derived from the currently selected carrier's shipment-scoped insurance limits (min/max)
  * and refresh automatically whenever that data changes — i.e. on carrier change AND on
  * packageType / deliveryType / weight / cc change, since those all narrow the shipment-scoped
  * capabilities response.
@@ -39,7 +39,7 @@ export const createInsuranceField = (
 
       // Watch the shipment-scoped carrier capabilities directly. The resolver tracks both the
       // selected carrier (via `form.getValue(FIELD_CARRIER)`) and the shipment-capabilities
-      // query data, so any axis change that updates `insuredAmount` triggers a refresh.
+      // query data, so any axis change that updates the insurance limits triggers a refresh.
       stopWatcher = watch(
         () => capabilities.getCarrierCapabilitiesForShipment(field.form),
         () => {

--- a/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
+++ b/apps/admin/src/forms/shipmentOptions/wireProxyCapabilities.ts
@@ -47,8 +47,8 @@ const resolveOrderInput = (form: FormInstance, order: Plugin.ModelContextOrderDa
  * - **Order query** drives the carrier / packageType / deliveryType dropdowns from each
  *   carrier's flat union arrays. Refetches only when destination, weight or the recipient
  *   business flag change.
- * - **Shipment query** drives per-option metadata (`isRequired`, `requires`, `excludes`,
- *   `insuredAmount`) for the chosen combination. Refetches when any axis of the selection
+ * - **Shipment query** drives per-option metadata (`isRequired`, `requires`, `excludes`, and the
+ *   insurance `min` / `max`) for the chosen combination. Refetches when any axis of the selection
  *   changes; the empty-result case is the invalid-combo signal consumed by
  *   `useCapabilitiesAutoClear`.
  *

--- a/libs/common/src/types/carrier.types.ts
+++ b/libs/common/src/types/carrier.types.ts
@@ -13,19 +13,21 @@ export type CarrierModel = {
       isSelectedByDefault: boolean;
       requires?: string[];
       excludes?: string[];
-      insuredAmount: {
-        min: {
-          amount: number;
-          currency: string;
-        };
-        max: {
-          amount: number;
-          currency: string;
-        };
-        default: {
-          amount: number;
-          currency: string;
-        };
+      /**
+       * Insurance limits, in cents. Each is optional: a missing `max` means the carrier sets no
+       * ceiling, and a missing `min` means it sets no floor.
+       */
+      min?: {
+        amount: number;
+        currency: string;
+      };
+      max?: {
+        amount: number;
+        currency: string;
+      };
+      default?: {
+        amount: number;
+        currency: string;
       };
     };
   } & Record<


### PR DESCRIPTION
reads insurance limits in the admin from the flat capabilities format instead of the nested wrapper the API is removing.

The MyParcel API is dropping the old nested wrapper around insurance limits from its capabilities response (Core API story SB-2770). The admin read the limits through that wrapper, and it failed quietly: with no limits found the maximum fell back to zero, which returns an empty list, so the insurance dropdown on the order form would simply be empty with no error anywhere.

Limits now come from the flat min and max fields the PDK hands over. Both are optional on the type, so a carrier that advertises insurance without a maximum yields no brackets rather than breaking — the same "nothing to enumerate" behaviour the PDK settings ladder has. Aside from where it reads, `getInsuranceOptions` is unchanged: a missing maximum and a zero maximum still behave the same.

Needs the matching PDK change to be released first, since the PDK is what strips the nested wrapper and hands over the flat fields (myparcelnl/pdk#511). Together those two must ship before SB-2770 deploys.

Resolves INT-1697
Part of INT-1695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

