### PR TITLE
fix(deps): ensure a compatible vue version is used

### DIFF
--- a/apps/admin-component-tests/package.json
+++ b/apps/admin-component-tests/package.json
@@ -39,11 +39,11 @@
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "vue": "3.5.40",
+    "vue": "3.4.31",
     "vue-tsc": "^3.3.9"
   },
   "peerDependencies": {
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "engines": {
     "node": ">=20"

--- a/apps/admin-demo/package.json
+++ b/apps/admin-demo/package.json
@@ -28,7 +28,7 @@
     "@myparcel-dev/pdk-admin-preset-fontawesome": "workspace:*",
     "@myparcel-dev/ts-utils": "^1.15.0",
     "@tanstack/vue-query": "~4.43.0",
-    "vue": "3.5.40",
+    "vue": "3.4.31",
     "vue-router": "^4.1.6"
   },
   "devDependencies": {

--- a/apps/admin-preset-bootstrap4/package.json
+++ b/apps/admin-preset-bootstrap4/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@myparcel-dev/pdk-admin": "workspace:^2.1.0",
     "@myparcel-dev/ts-utils": "^1.15.0",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/pdk-admin-component-tests": "workspace:*",

--- a/apps/admin-preset-dashicons/package.json
+++ b/apps/admin-preset-dashicons/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@myparcel-dev/pdk-admin": "workspace:^2.1.0",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/pdk-admin-component-tests": "workspace:*",

--- a/apps/admin-preset-default/package.json
+++ b/apps/admin-preset-default/package.json
@@ -31,7 +31,7 @@
     "@myparcel-dev/ts-utils": "^1.15.0",
     "@vuepic/vue-datepicker": "^11.0.2",
     "@vueuse/core": "^10.0.0",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/pdk-admin-component-tests": "workspace:*",

--- a/apps/admin-preset-fontawesome/package.json
+++ b/apps/admin-preset-fontawesome/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@myparcel-dev/pdk-admin": "workspace:^2.1.0",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/pdk-admin-component-tests": "workspace:*",

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -46,7 +46,7 @@
     "lodash-es": "^4.17.21",
     "lodash-unified": "^1.0.3",
     "pinia": "^2.0.0",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/pdk-build-vite": "workspace:*",

--- a/libs/build-vite/package.json
+++ b/libs/build-vite/package.json
@@ -25,7 +25,7 @@
     "vite-plugin-custom-tsconfig": "^1.0.4",
     "vite-plugin-dts": "^4.3.0",
     "vitest": "^3.2.6",
-    "vue": "3.5.40"
+    "vue": "3.4.31"
   },
   "devDependencies": {
     "@myparcel-dev/ts-utils": "^1.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2030,10 +2030,10 @@ __metadata:
     pinia: "npm:^2.0.0"
     typescript: "npm:^5.2.2"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   peerDependencies:
-    vue: 3.5.40
+    vue: 3.4.31
   languageName: unknown
   linkType: soft
 
@@ -2057,7 +2057,7 @@ __metadata:
     vite: "npm:^5.4.10"
     vite-plugin-custom-tsconfig: "npm:^1.0.4"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-router: "npm:^4.1.6"
   languageName: unknown
   linkType: soft
@@ -2089,7 +2089,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.4.10"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   languageName: unknown
   linkType: soft
@@ -2104,7 +2104,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.4.10"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   languageName: unknown
   linkType: soft
@@ -2122,7 +2122,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.4.10"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   languageName: unknown
   linkType: soft
@@ -2137,7 +2137,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.4.10"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   languageName: unknown
   linkType: soft
@@ -2162,7 +2162,7 @@ __metadata:
     typescript: "npm:^5.2.2"
     vite: "npm:^5.4.10"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
     vue-tsc: "npm:^3.3.9"
   languageName: unknown
   linkType: soft
@@ -2218,7 +2218,7 @@ __metadata:
     vite-plugin-custom-tsconfig: "npm:^1.0.4"
     vite-plugin-dts: "npm:^4.3.0"
     vitest: "npm:^3.2.6"
-    vue: "npm:3.5.40"
+    vue: "npm:3.4.31"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Declares the vue version the form builder is actually tested with, instead of one that never gets installed.

Eight package.json files declared vue 3.5.40 while the root resolutions entry has always forced 3.4.31, so nothing in this repo ever ran 3.5.40. Only apps/admin-js was honest about it, with a peer of 3.4.31; this brings the rest into line with that rather than the other way round. Inside the js-pdk nothing changes: no resolved version moves, because the resolution was already winning.

The effect is entirely on consumers. Yarn only applies resolutions from the top-level project, so a plugin installing the js-pdk never inherits our pin and resolves the declared 3.5.40 instead. That means @myparcel-dev/vue-form-builder runs on a vue we never test it against, and in the WooCommerce plugin it currently ends up with two copies of vue side by side (3.5.40 and 3.5.41) — the duplicate-instance situation that stopped forms rendering in #294. The form builder is unmaintained, has no upgrade path and is already tagged for replacement, so 3.4.31 stays until it goes.

The root resolutions entry stays as a backstop, but stops being load-bearing: consumers now resolve 3.4.31 from the declarations alone. Checked that nothing depends on vue 3.5-only APIs before doing this — no useId, useTemplateRef, onWatcherCleanup, useShadowRoot or useHost, and no destructured defineProps, in this repo or in either plugin.

Stacked on #416 rather than targeting main. Refreshing the lockfile on main surfaces an unrelated failure: libs/checkout-common declares @myparcel-dev/delivery-options ^6.25.0, main's lockfile has no entry for that range, and resolving it pulls in v6 whose types break the checkout-delivery-options build (TS7053 on CarrierSetting.PackageType). #416 aligns that range to 7.x, which removes the problem, so this sits on top of it.

Background on the form builder constraint is written up in INT-1354.

Depends on https://github.com/myparcelnl/js-pdk/pull/416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
